### PR TITLE
fix(compiler): add aliases to FTS5 search index

### DIFF
--- a/crates/compiler/src/compile.rs
+++ b/crates/compiler/src/compile.rs
@@ -33,8 +33,8 @@ pub fn compile_manifests(conn: &Connection, manifests: &[Manifest]) -> anyhow::R
 
     // Populate FTS5 index
     tx.execute_batch(
-        "INSERT INTO packages_fts(rowid, name, description, tags, publisher)
-         SELECT rowid, name, description, tags, publisher FROM packages;",
+        "INSERT INTO packages_fts(rowid, name, description, tags, aliases, publisher)
+         SELECT rowid, name, description, tags, aliases, publisher FROM packages;",
     )?;
 
     // Write meta

--- a/crates/compiler/src/schema.rs
+++ b/crates/compiler/src/schema.rs
@@ -89,7 +89,7 @@ pub fn create_schema(conn: &Connection) -> anyhow::Result<()> {
         );
 
         CREATE VIRTUAL TABLE IF NOT EXISTS packages_fts USING fts5(
-            name, description, tags, publisher,
+            name, description, tags, aliases, publisher,
             content='packages', content_rowid='rowid'
         );
         ",


### PR DESCRIPTION
Aliases (e.g., "n.i.n.a." for NINA) were missing from the full-text search index, so alias-based searches would not return results.

## Changes
- `crates/compiler/src/schema.rs`: Add `aliases` column to `packages_fts` virtual table definition
- `crates/compiler/src/compile.rs`: Include `aliases` in the FTS5 INSERT statement when populating the index

## Impact
Now all five searchable columns are indexed: **name**, **description**, **tags**, **aliases**, **publisher**.

Users can now search by package aliases (e.g., searching for "n.i.n.a." will correctly return the NINA package).
