### PR TITLE
fix(ci): decode base64-encoded minisign key in pipeline

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -75,7 +75,7 @@ jobs:
         env:
           MINISIGN_KEY: ${{ secrets.MINISIGN_KEY }}
         run: |
-          printf '%s\n' "$MINISIGN_KEY" > /tmp/minisign.key
+          echo "$MINISIGN_KEY" | base64 -d > /tmp/minisign.key
           minisign -Sm catalog.db -s /tmp/minisign.key -t "catalog $(date -u +%Y-%m-%dT%H:%M:%SZ)"
           rm /tmp/minisign.key
 


### PR DESCRIPTION
MINISIGN_KEY secret is base64-encoded to preserve newlines through GitHub secrets storage.