### PR TITLE
ci: skip Rust checks when no Rust files changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,27 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  check:
-    name: Rust Checks
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            rust:
+              - 'crates/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'manifests/**'
+
+  rust:
+    name: Rust CI
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -38,3 +57,19 @@ jobs:
       - run: cargo test --workspace
       - name: Validate manifests
         run: cargo run -p astro-up-compiler -- --manifests manifests --validate
+
+  # Gate job: always runs, reports the required "Rust Checks" status.
+  # Passes when rust CI succeeds or was skipped (no Rust changes).
+  check:
+    name: Rust Checks
+    needs: [changes, rust]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Gate
+        env:
+          RUST_RESULT: ${{ needs.rust.result }}
+        run: |
+          if [ "$RUST_RESULT" = "failure" ] || [ "$RUST_RESULT" = "cancelled" ]; then
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Add path filtering to CI so Rust checks only run when Rust files change
- Gate job provides the required "Rust Checks" status even when the actual CI is skipped
- Fixes pipeline bot push failure — version file commits no longer trigger a required Rust build

## Test plan
- [ ] CI passes on this PR (Rust files changed, so full CI runs)
- [ ] After merge, trigger pipeline manually — bot commit should push successfully
