### PR TITLE
fix: stealth browser, realistic user agent, manual writes latest

### DIFF
--- a/crates/checker/src/main.rs
+++ b/crates/checker/src/main.rs
@@ -92,7 +92,7 @@ async fn main() -> anyhow::Result<()> {
     // 4. Build HTTP client with retry middleware
     let retry_policy = ExponentialBackoff::builder().build_with_max_retries(2);
     let raw_client = reqwest::Client::builder()
-        .user_agent("astro-up-checker/0.1")
+        .user_agent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36")
         .timeout(std::time::Duration::from_secs(30))
         .build()?;
     let client = ClientBuilder::new(raw_client)

--- a/crates/checker/src/providers/browser_scrape.rs
+++ b/crates/checker/src/providers/browser_scrape.rs
@@ -4,6 +4,14 @@ use std::time::Duration;
 
 use super::{CheckError, CheckOutcome, CheckResult};
 
+/// Stealth JS to inject before page load — hides automation signals.
+const STEALTH_JS: &str = r#"
+Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
+Object.defineProperty(navigator, 'plugins', { get: () => [1, 2, 3, 4, 5] });
+Object.defineProperty(navigator, 'languages', { get: () => ['en-US', 'en'] });
+window.chrome = { runtime: {} };
+"#;
+
 pub async fn check(_manifest: &Manifest, checkver: &Checkver) -> Result<CheckOutcome, CheckError> {
     let url = checkver
         .url
@@ -21,11 +29,12 @@ pub async fn check(_manifest: &Manifest, checkver: &Checkver) -> Result<CheckOut
     let user_data_dir = tempfile::tempdir()
         .map_err(|e| CheckError::Browser(format!("failed to create temp dir: {e}")))?;
 
-    // Launch browser
+    // Launch browser with anti-detection flags
     let (mut browser, mut handler) = chromiumoxide::Browser::launch(
         chromiumoxide::BrowserConfig::builder()
             .request_timeout(page_timeout)
             .user_data_dir(user_data_dir.path())
+            .arg("--disable-blink-features=AutomationControlled")
             .build()
             .map_err(|e| CheckError::Browser(format!("config error: {e}")))?,
     )
@@ -37,7 +46,16 @@ pub async fn check(_manifest: &Manifest, checkver: &Checkver) -> Result<CheckOut
 
     let result = async {
         let page = browser
-            .new_page(url)
+            .new_page("about:blank")
+            .await
+            .map_err(|e| CheckError::Browser(format!("navigation error: {e}")))?;
+
+        // Inject stealth scripts before navigating to target
+        page.evaluate(STEALTH_JS)
+            .await
+            .map_err(|e| CheckError::Browser(format!("stealth inject error: {e}")))?;
+
+        page.goto(url)
             .await
             .map_err(|e| CheckError::Browser(format!("navigation error: {e}")))?;
 

--- a/crates/checker/src/providers/manual.rs
+++ b/crates/checker/src/providers/manual.rs
@@ -1,10 +1,14 @@
 use astro_up_shared::manifest::Manifest;
 
-use super::CheckOutcome;
+use super::{CheckOutcome, CheckResult};
 
 pub fn check(manifest: &Manifest) -> CheckOutcome {
-    tracing::info!("{}: manual — requires human update", manifest.id);
-    CheckOutcome::Skipped {
-        reason: "manual: requires human update".into(),
-    }
+    tracing::info!("{}: manual — writing 'latest' as version", manifest.id);
+    CheckOutcome::Found(CheckResult {
+        version: "latest".into(),
+        url: None,
+        sha256: None,
+        release_notes_url: None,
+        pre_release: false,
+    })
 }

--- a/manifests/zwo-ascom-driver-pack.toml
+++ b/manifests/zwo-ascom-driver-pack.toml
@@ -21,7 +21,7 @@ elevation = true
 silent = "/S"
 
 [checkver]
-provider = "direct_url"
+provider = "http_head"
 url = "https://dl.zwoastro.com/software?app=ASCOMDrive&platform=windows64&region=Overseas"
 regex = 'filename=ZWO_ASCOM_Setup_V(\d+\.\d+\.\d+)\.exe'
 

--- a/manifests/zwo-asistudio.toml
+++ b/manifests/zwo-asistudio.toml
@@ -23,7 +23,7 @@ elevation = true
 silent = "/S"
 
 [checkver]
-provider = "direct_url"
+provider = "http_head"
 url = "https://dl.zwoastro.com/software?app=ASIStudio&platform=windows64&region=Overseas"
 regex = 'filename=ASIStudio_V(\d+\.\d+(?:\.\d+)*)_'
 

--- a/manifests/zwo-firmware-tool.toml
+++ b/manifests/zwo-firmware-tool.toml
@@ -20,7 +20,7 @@ elevation = true
 silent = "/S"
 
 [checkver]
-provider = "direct_url"
+provider = "http_head"
 url = "https://dl.zwoastro.com/software?app=FirmwareUpgradeTool&platform=windows86&region=Overseas"
 regex = 'filename=FWUpdate_Windows_v(\d+\.\d+\.\d+)\.'
 

--- a/manifests/zwo-native-driver.toml
+++ b/manifests/zwo-native-driver.toml
@@ -21,7 +21,7 @@ elevation = true
 silent = "/S"
 
 [checkver]
-provider = "direct_url"
+provider = "http_head"
 url = "https://dl.zwoastro.com/software?app=AsiCameraDriver&platform=windows64&region=Overseas"
 regex = 'filename=ZWO_ASI_Cameras_driver_Setup_V(\d+\.\d+\.\d+\.\d+)\.exe'
 


### PR DESCRIPTION
## Summary
- Add stealth JS injection to browser_scrape (hide webdriver, fake plugins/languages, chrome runtime) + `--disable-blink-features=AutomationControlled` flag
- Switch HTTP user agent from `astro-up-checker/0.1` to a real Chrome UA to avoid bot blocking (fixes ZWO, dotnet)
- Manual provider now writes `version: "latest"` instead of skipping (12 packages get a version entry)
- Switch 4 ZWO manifests from direct_url to http_head (version is in redirect headers, not body)

## Test plan
- [ ] CI passes
- [ ] After merge, trigger pipeline — more packages should discover versions
- [ ] Manual packages should have `latest` as version in catalog
