### PR TITLE
fix: switch ZWO and dotnet to browser_scrape with SPA tab support

### DIFF
--- a/crates/checker/src/providers/browser_scrape.rs
+++ b/crates/checker/src/providers/browser_scrape.rs
@@ -1,4 +1,5 @@
 use astro_up_shared::manifest::{Checkver, Manifest};
+use chromiumoxide::cdp::browser_protocol::page::AddScriptToEvaluateOnNewDocumentParams;
 use futures::StreamExt;
 use std::time::Duration;
 
@@ -50,8 +51,8 @@ pub async fn check(_manifest: &Manifest, checkver: &Checkver) -> Result<CheckOut
             .await
             .map_err(|e| CheckError::Browser(format!("navigation error: {e}")))?;
 
-        // Inject stealth scripts before navigating to target
-        page.evaluate(STEALTH_JS)
+        // Inject stealth scripts on every new document (including navigations)
+        page.execute(AddScriptToEvaluateOnNewDocumentParams::new(STEALTH_JS))
             .await
             .map_err(|e| CheckError::Browser(format!("stealth inject error: {e}")))?;
 
@@ -62,6 +63,20 @@ pub async fn check(_manifest: &Manifest, checkver: &Checkver) -> Result<CheckOut
         page.wait_for_navigation()
             .await
             .map_err(|e| CheckError::Browser(format!("wait error: {e}")))?;
+
+        // If a css_selector is provided, click it and wait for content to update (SPA tab switch)
+        if let Some(selector) = &checkver.css_selector {
+            // Wait for the element to appear
+            let element = page.find_element(selector).await.map_err(|e| {
+                CheckError::Browser(format!("selector '{selector}' not found: {e}"))
+            })?;
+            element
+                .click()
+                .await
+                .map_err(|e| CheckError::Browser(format!("click error: {e}")))?;
+            // Wait for SPA content to render
+            tokio::time::sleep(Duration::from_secs(3)).await;
+        }
 
         // Extract page content with extraction timeout
         let content = tokio::time::timeout(extraction_timeout, page.content())

--- a/manifests/dotnet-desktop-8.toml
+++ b/manifests/dotnet-desktop-8.toml
@@ -21,9 +21,9 @@ elevation = true
 silent = "/install /quiet /norestart"
 
 [checkver]
-provider = "direct_url"
-url = "https://aka.ms/dotnet/8.0/windowsdesktop-runtime-win-x64.exe"
-regex = 'windowsdesktop-runtime-(\d+\.\d+\.\d+)-win'
+provider = "browser_scrape"
+url = "https://dotnet.microsoft.com/en-us/download/dotnet/8.0"
+regex = '\.NET 8.*?(\d+\.\d+\.\d+)'
 
 [checkver.autoupdate]
 url = "https://aka.ms/dotnet/8.0/windowsdesktop-runtime-win-x64.exe"

--- a/manifests/zwo-ascom-driver-pack.toml
+++ b/manifests/zwo-ascom-driver-pack.toml
@@ -21,9 +21,10 @@ elevation = true
 silent = "/S"
 
 [checkver]
-provider = "http_head"
-url = "https://dl.zwoastro.com/software?app=ASCOMDrive&platform=windows64&region=Overseas"
-regex = 'filename=ZWO_ASCOM_Setup_V(\d+\.\d+\.\d+)\.exe'
+provider = "browser_scrape"
+url = "https://www.zwoastro.com/software/"
+css_selector = ".e-n-tab-title:nth-child(2)"
+regex = 'ASCOM.*?[Vv](\d+\.\d+\.\d+)'
 
 [checkver.autoupdate]
 url = "https://dl.zwoastro.com/software?app=ASCOMDrive&platform=windows64&region=Overseas"

--- a/manifests/zwo-asi-driver.toml
+++ b/manifests/zwo-asi-driver.toml
@@ -20,10 +20,10 @@ scope = "machine"
 elevation = true
 
 [checkver]
-provider = "html_scrape"
+provider = "browser_scrape"
 url = "https://www.zwoastro.com/software/"
-regex = "ASI Camera.*?v?(\\d+\\.\\d+\\.\\d+)"
-version_format = "semver"
+css_selector = ".e-n-tab-title:nth-child(2)"
+regex = 'ASI Cameras.*?[Vv](\d+\.\d+\.\d+(?:\.\d+)?)'
 
 [hardware]
 device_class = "Camera"

--- a/manifests/zwo-asistudio.toml
+++ b/manifests/zwo-asistudio.toml
@@ -23,9 +23,10 @@ elevation = true
 silent = "/S"
 
 [checkver]
-provider = "http_head"
-url = "https://dl.zwoastro.com/software?app=ASIStudio&platform=windows64&region=Overseas"
-regex = 'filename=ASIStudio_V(\d+\.\d+(?:\.\d+)*)_'
+provider = "browser_scrape"
+url = "https://www.zwoastro.com/software/"
+css_selector = ".e-n-tab-title:nth-child(2)"
+regex = 'ASIStudio.*?[Vv](\d+\.\d+(?:\.\d+)?)'
 
 [checkver.autoupdate]
 url = "https://dl.zwoastro.com/software?app=ASIStudio&platform=windows64&region=Overseas"

--- a/manifests/zwo-firmware-tool.toml
+++ b/manifests/zwo-firmware-tool.toml
@@ -20,9 +20,10 @@ elevation = true
 silent = "/S"
 
 [checkver]
-provider = "http_head"
-url = "https://dl.zwoastro.com/software?app=FirmwareUpgradeTool&platform=windows86&region=Overseas"
-regex = 'filename=FWUpdate_Windows_v(\d+\.\d+\.\d+)\.'
+provider = "browser_scrape"
+url = "https://www.zwoastro.com/software/"
+css_selector = ".e-n-tab-title:nth-child(2)"
+regex = 'Firmware.*?Tool.*?[Vv](\d+\.\d+\.\d+)'
 
 [checkver.autoupdate]
 url = "https://dl.zwoastro.com/software?app=FirmwareUpgradeTool&platform=windows86&region=Overseas"

--- a/manifests/zwo-native-driver.toml
+++ b/manifests/zwo-native-driver.toml
@@ -21,9 +21,10 @@ elevation = true
 silent = "/S"
 
 [checkver]
-provider = "http_head"
-url = "https://dl.zwoastro.com/software?app=AsiCameraDriver&platform=windows64&region=Overseas"
-regex = 'filename=ZWO_ASI_Cameras_driver_Setup_V(\d+\.\d+\.\d+\.\d+)\.exe'
+provider = "browser_scrape"
+url = "https://www.zwoastro.com/software/"
+css_selector = ".e-n-tab-title:nth-child(2)"
+regex = 'Native Camera.*?[Vv](\d+\.\d+\.\d+(?:\.\d+)?)'
 
 [checkver.autoupdate]
 url = "https://dl.zwoastro.com/software?app=AsiCameraDriver&platform=windows64&region=Overseas"


### PR DESCRIPTION
## Summary
- Switch 5 ZWO + 1 dotnet manifests to browser_scrape (SPA pages block HTTP requests)
- Add css_selector click support to browser_scrape provider for SPA tab switching
- ZWO manifests scrape the software page with Desktop App tab click
- dotnet scrapes the official .NET 8 download page
- Use `AddScriptToEvaluateOnNewDocumentParams` for stealth injection (persists across navigations)

## Test plan
- [ ] CI passes
- [ ] After merge, trigger pipeline — all 96 packages should have versions
