### PR TITLE
feat: extract download URLs from links, add autoupdate templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "url",
  "walkdir",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,4 @@ chromiumoxide = { version = "0.8", features = ["tokio"] }
 lenient_semver = "0.4"
 base64 = "0.22"
 tempfile = "3"
+url = "2"

--- a/crates/checker/Cargo.toml
+++ b/crates/checker/Cargo.toml
@@ -31,3 +31,4 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 walkdir.workspace = true
 tempfile.workspace = true
+url.workspace = true

--- a/crates/checker/src/providers/html_scrape.rs
+++ b/crates/checker/src/providers/html_scrape.rs
@@ -4,6 +4,58 @@ use scraper::{Html, Selector};
 
 use super::{CheckError, CheckOutcome, CheckResult};
 
+/// Try to extract the download URL from an `<a>` element's href.
+/// Resolves relative URLs against the base page URL.
+fn extract_href(element: &scraper::ElementRef, base_url: &str) -> Option<String> {
+    let href = element.value().attr("href")?;
+    if href.starts_with("http://") || href.starts_with("https://") {
+        Some(href.to_string())
+    } else if href.starts_with('/') {
+        // Resolve relative URL against base
+        url::Url::parse(base_url)
+            .ok()
+            .and_then(|base| base.join(href).ok())
+            .map(|u| u.to_string())
+    } else {
+        Some(href.to_string())
+    }
+}
+
+/// Search `<a>` elements for hrefs matching the regex, returning both version and URL.
+fn find_version_in_links(
+    document: &Html,
+    re: &regex::Regex,
+    selector: Option<&Selector>,
+    base_url: &str,
+) -> Option<CheckResult> {
+    let a_selector = Selector::parse("a[href]").ok()?;
+
+    let elements: Box<dyn Iterator<Item = scraper::ElementRef>> = if let Some(scope) = selector {
+        // Search <a> tags within the scoped elements
+        Box::new(document.select(scope).flat_map(|el| el.select(&a_selector)))
+    } else {
+        Box::new(document.select(&a_selector))
+    };
+
+    for element in elements {
+        if let Some(href) = element.value().attr("href") {
+            if let Some(caps) = re.captures(href) {
+                if let Some(m) = caps.get(1) {
+                    return Some(CheckResult {
+                        version: m.as_str().to_string(),
+                        url: extract_href(&element, base_url),
+                        sha256: None,
+                        release_notes_url: None,
+                        pre_release: false,
+                    });
+                }
+            }
+        }
+    }
+
+    None
+}
+
 pub async fn check(
     _manifest: &Manifest,
     checkver: &Checkver,
@@ -20,20 +72,33 @@ pub async fn check(
 
     let resp = client.get(url).send().await?;
     super::check_rate_limit(&resp)?;
+    let final_url = resp.url().to_string();
     let body = resp.text().await?;
 
     let re = regex::Regex::new(regex_pat)
         .map_err(|e| CheckError::Other(format!("invalid regex: {e}")))?;
 
-    // Parse HTML with scraper and extract text from the DOM, then apply regex.
-    // If a css_selector is configured, narrow the search to matching elements.
     let document = Html::parse_document(&body);
 
-    if let Some(css) = checkver.css_selector.as_deref() {
-        let selector = Selector::parse(css)
-            .map_err(|e| CheckError::Other(format!("invalid CSS selector: {e}")))?;
+    // Build optional CSS scope selector
+    let scope_selector = checkver
+        .css_selector
+        .as_deref()
+        .map(|css| {
+            Selector::parse(css)
+                .map_err(|e| CheckError::Other(format!("invalid CSS selector: {e}")))
+        })
+        .transpose()?;
 
-        for element in document.select(&selector) {
+    // First: search <a href> attributes for the regex — captures both version and download URL
+    if let Some(result) = find_version_in_links(&document, &re, scope_selector.as_ref(), &final_url)
+    {
+        return Ok(CheckOutcome::Found(result));
+    }
+
+    // Second: search element text within CSS scope
+    if let Some(scope) = &scope_selector {
+        for element in document.select(scope) {
             let text = element.text().collect::<String>();
             if let Some(caps) = re.captures(&text) {
                 if let Some(m) = caps.get(1) {
@@ -46,24 +111,10 @@ pub async fn check(
                     }));
                 }
             }
-            // Also check element attributes (href, data-version, etc.)
-            for attr_val in element.value().attrs().map(|(_, v)| v) {
-                if let Some(caps) = re.captures(attr_val) {
-                    if let Some(m) = caps.get(1) {
-                        return Ok(CheckOutcome::Found(CheckResult {
-                            version: m.as_str().to_string(),
-                            url: None,
-                            sha256: None,
-                            release_notes_url: None,
-                            pre_release: false,
-                        }));
-                    }
-                }
-            }
         }
     }
 
-    // Fallback: apply regex to the full page body (same as direct_url behavior)
+    // Third: apply regex to the full page body
     let caps = re.captures(&body).ok_or(CheckError::NoMatch)?;
     let version = caps.get(1).ok_or(CheckError::NoMatch)?.as_str().to_string();
 

--- a/manifests/green-swamp-server-app.toml
+++ b/manifests/green-swamp-server-app.toml
@@ -22,3 +22,6 @@ silent = "/VERYSILENT /NORESTART /SUPPRESSMSGBOXES"
 provider = "github"
 owner = "rmorgan001"
 repo = "GS.Point3d"
+
+[checkver.autoupdate]
+url = "https://github.com/rmorgan001/GS.Point3d/releases/download/v$version/GreenSwampServer-$version-Setup.exe"

--- a/manifests/ioptron-cem120-firmware.toml
+++ b/manifests/ioptron-cem120-firmware.toml
@@ -13,7 +13,7 @@ method = "exe"
 elevation = true
 
 [checkver]
-provider = "browser_scrape"
+provider = "html_scrape"
 url = "https://www.ioptron.com/Articles.asp?ID=309"
 regex = 'FW(\d{6})'
 

--- a/manifests/ioptron-cem26-firmware.toml
+++ b/manifests/ioptron-cem26-firmware.toml
@@ -13,7 +13,7 @@ method = "exe"
 elevation = true
 
 [checkver]
-provider = "browser_scrape"
+provider = "html_scrape"
 url = "https://www.ioptron.com/Articles.asp?ID=333"
 regex = 'FW(\d{6})'
 

--- a/manifests/ioptron-cem40-firmware.toml
+++ b/manifests/ioptron-cem40-firmware.toml
@@ -13,7 +13,7 @@ method = "exe"
 elevation = true
 
 [checkver]
-provider = "browser_scrape"
+provider = "html_scrape"
 url = "https://www.ioptron.com/Articles.asp?ID=318"
 regex = 'FW(\d{6})'
 

--- a/manifests/ioptron-cem70-firmware.toml
+++ b/manifests/ioptron-cem70-firmware.toml
@@ -13,7 +13,7 @@ method = "exe"
 elevation = true
 
 [checkver]
-provider = "browser_scrape"
+provider = "html_scrape"
 url = "https://www.ioptron.com/Articles.asp?ID=326"
 regex = 'FW(\d{6})'
 

--- a/manifests/ioptron-commander-ascom.toml
+++ b/manifests/ioptron-commander-ascom.toml
@@ -19,7 +19,7 @@ elevation = true
 silent = "/S"
 
 [checkver]
-provider = "browser_scrape"
+provider = "html_scrape"
 url = "https://www.ioptron.com/Articles.asp?ID=337"
 regex = 'Installer(\d+)\.exe'
 

--- a/manifests/ioptron-hae-bc-firmware.toml
+++ b/manifests/ioptron-hae-bc-firmware.toml
@@ -13,7 +13,7 @@ method = "exe"
 elevation = true
 
 [checkver]
-provider = "browser_scrape"
+provider = "html_scrape"
 url = "https://www.ioptron.com/Articles.asp?ID=360"
 regex = 'FW(\d{6})'
 

--- a/manifests/ioptron-hae-firmware.toml
+++ b/manifests/ioptron-hae-firmware.toml
@@ -13,7 +13,7 @@ method = "exe"
 elevation = true
 
 [checkver]
-provider = "browser_scrape"
+provider = "html_scrape"
 url = "https://www.ioptron.com/Articles.asp?ID=348"
 regex = 'FW(\d{6})'
 

--- a/manifests/ioptron-haz-firmware.toml
+++ b/manifests/ioptron-haz-firmware.toml
@@ -13,7 +13,7 @@ method = "exe"
 elevation = true
 
 [checkver]
-provider = "browser_scrape"
+provider = "html_scrape"
 url = "https://www.ioptron.com/Articles.asp?ID=349"
 regex = 'FW(\d{6})'
 

--- a/manifests/ioptron-hem-firmware.toml
+++ b/manifests/ioptron-hem-firmware.toml
@@ -13,7 +13,7 @@ method = "exe"
 elevation = true
 
 [checkver]
-provider = "browser_scrape"
+provider = "html_scrape"
 url = "https://www.ioptron.com/Articles.asp?ID=345"
 regex = 'FW(\d{6})'
 

--- a/manifests/ioptron-upgrade-utility-v2.toml
+++ b/manifests/ioptron-upgrade-utility-v2.toml
@@ -19,7 +19,7 @@ elevation = true
 silent = "/S"
 
 [checkver]
-provider = "browser_scrape"
+provider = "html_scrape"
 url = "https://www.ioptron.com/Articles.asp?ID=309"
 regex = 'Utility(\d{3})\.exe'
 

--- a/manifests/ioptron-upgrade-utility-v3.toml
+++ b/manifests/ioptron-upgrade-utility-v3.toml
@@ -19,7 +19,7 @@ elevation = true
 silent = "/S"
 
 [checkver]
-provider = "browser_scrape"
+provider = "html_scrape"
 url = "https://www.ioptron.com/Articles.asp?ID=360"
 regex = 'Utility(\d{3})\.exe'
 

--- a/manifests/nexdome-ascom.toml
+++ b/manifests/nexdome-ascom.toml
@@ -20,5 +20,8 @@ provider = "github"
 owner = "nexdome"
 repo = "ASCOM"
 
+[checkver.autoupdate]
+url = "https://github.com/nexdome/ASCOM/releases/download/v$version/NexDome-Setup.exe"
+
 [dependencies]
 requires = ["ascom-platform"]

--- a/manifests/phd2-app.toml
+++ b/manifests/phd2-app.toml
@@ -23,3 +23,6 @@ silent = "/VERYSILENT /NORESTART /SUPPRESSMSGBOXES"
 provider = "github"
 owner = "OpenPHDGuiding"
 repo = "phd2"
+
+[checkver.autoupdate]
+url = "https://openphdguiding.org/phd2-$version-installer.exe"

--- a/manifests/prolific-drivers.toml
+++ b/manifests/prolific-drivers.toml
@@ -22,3 +22,6 @@ silent = "/S"
 
 [checkver]
 provider = "manual"
+
+[checkver.autoupdate]
+url = "https://www.prolific.com.tw/UserFiles/files/PL23XX-M_LogoDriver_Setup_v208_20221028.exe"

--- a/manifests/qhy-allinone-beta.toml
+++ b/manifests/qhy-allinone-beta.toml
@@ -25,5 +25,8 @@ provider = "browser_scrape"
 url = "https://www.qhyccd.com/download/"
 regex = 'Ver\. (\d{8})\(Beta\)'
 
+[checkver.autoupdate]
+url = "https://www.qhyccd.com/file/repository/AllInOne/V$version/QHY_AllInOne_V$version.exe"
+
 [dependencies]
 requires = ["ascom-platform"]

--- a/manifests/qhy-allinone.toml
+++ b/manifests/qhy-allinone.toml
@@ -25,5 +25,8 @@ provider = "browser_scrape"
 url = "https://www.qhyccd.com/download/"
 regex = 'Ver\. (\d{8}) \(Recommended\)'
 
+[checkver.autoupdate]
+url = "https://www.qhyccd.com/file/repository/AllInOne/V$version/QHY_AllInOne_V$version.exe"
+
 [dependencies]
 requires = ["ascom-platform"]

--- a/manifests/stellarium-app.toml
+++ b/manifests/stellarium-app.toml
@@ -23,3 +23,6 @@ silent = "/VERYSILENT /NORESTART /SUPPRESSMSGBOXES"
 provider = "github"
 owner = "Stellarium"
 repo = "stellarium"
+
+[checkver.autoupdate]
+url = "https://github.com/Stellarium/stellarium/releases/download/v$version/stellarium-$version-win64.exe"

--- a/manifests/wanderer-empire.toml
+++ b/manifests/wanderer-empire.toml
@@ -19,3 +19,6 @@ elevation = true
 provider = "browser_scrape"
 url = "https://www.wandererastro.com/en/h-col-106.html"
 regex = 'WandererEmpire-V(\d+\.\d+\.\d+)-Setup'
+
+[checkver.autoupdate]
+url = "https://www.wandererastro.com/download/WandererEmpire-V$version-Setup.exe"


### PR DESCRIPTION
## Summary
- Enhance `html_scrape` to extract download URLs from `<a href>` attributes (like Go's `ExtractLinks`) — auto-populates URLs for most html_scrape packages
- Move 11 iOptron packages from browser_scrape to html_scrape (static ASP pages, no JS needed)
- Add autoupdate URL templates for GitHub packages (phd2, stellarium, nexdome, green-swamp-server) and known URL patterns (wanderer-empire, qhy, prolific)

## Test plan
- [ ] CI passes
- [ ] After merge, trigger pipeline — packages should now have download URLs populated
- [ ] Verify iOptron packages work with html_scrape (no more Chromium needed)
