### PR TITLE
fix: switch 3 remaining ZWO packages to manual

### DIFF
--- a/manifests/zwo-asi-driver.toml
+++ b/manifests/zwo-asi-driver.toml
@@ -20,10 +20,10 @@ scope = "machine"
 elevation = true
 
 [checkver]
-provider = "browser_scrape"
-url = "https://www.zwoastro.com/software/"
-css_selector = "js:document.querySelectorAll('.elementor-tab-title').forEach(t => { if (t.textContent.trim() === 'Desktop App') t.click() })"
-regex = 'ASI Cameras.*?[Vv](\d+\.\d+\.\d+(?:\.\d+)?)'
+provider = "manual"
+
+[checkver.autoupdate]
+url = "https://dl.zwoastro.com/software?app=AsiCameraDriver&platform=windows64&region=Overseas"
 
 [hardware]
 device_class = "Camera"

--- a/manifests/zwo-firmware-tool.toml
+++ b/manifests/zwo-firmware-tool.toml
@@ -20,10 +20,7 @@ elevation = true
 silent = "/S"
 
 [checkver]
-provider = "browser_scrape"
-url = "https://www.zwoastro.com/software/"
-css_selector = "js:document.querySelectorAll('.elementor-tab-title').forEach(t => { if (t.textContent.trim() === 'Desktop App') t.click() })"
-regex = 'Firmware.*?Tool.*?[Vv](\d+\.\d+\.\d+)'
+provider = "manual"
 
 [checkver.autoupdate]
 url = "https://dl.zwoastro.com/software?app=FirmwareUpgradeTool&platform=windows86&region=Overseas"

--- a/manifests/zwo-native-driver.toml
+++ b/manifests/zwo-native-driver.toml
@@ -21,10 +21,7 @@ elevation = true
 silent = "/S"
 
 [checkver]
-provider = "browser_scrape"
-url = "https://www.zwoastro.com/software/"
-css_selector = "js:document.querySelectorAll('.elementor-tab-title').forEach(t => { if (t.textContent.trim() === 'Desktop App') t.click() })"
-regex = 'Native Camera.*?[Vv](\d+\.\d+\.\d+(?:\.\d+)?)'
+provider = "manual"
 
 [checkver.autoupdate]
 url = "https://dl.zwoastro.com/software?app=AsiCameraDriver&platform=windows64&region=Overseas"


### PR DESCRIPTION
## Summary
Switch 3 remaining ZWO packages (zwo-asi-driver, zwo-firmware-tool, zwo-native-driver) to manual provider. ZWO's software page is a Vue SPA with dynamically loaded tab content that resists all scraping approaches tried (browser_scrape with JS click, WP REST API, direct HTTP). Download URLs preserved in autoupdate sections.

## Test plan
- [ ] CI passes
- [ ] After merge + pipeline, all 96 packages should have versions (96/96)
