### PR TITLE
fix: switch 3 remaining ZWO manifests to redirect provider

### DIFF
--- a/manifests/zwo-asi-driver.toml
+++ b/manifests/zwo-asi-driver.toml
@@ -20,10 +20,9 @@ scope = "machine"
 elevation = true
 
 [checkver]
-provider = "manual"
-
-[checkver.autoupdate]
+provider = "redirect"
 url = "https://dl.zwoastro.com/software?app=AsiCameraDriver&platform=windows64&region=Overseas"
+regex = 'ASI_Cameras_driver_Setup_V(\d+\.\d+\.\d+(?:\.\d+)?)\.exe'
 
 [hardware]
 device_class = "Camera"

--- a/manifests/zwo-firmware-tool.toml
+++ b/manifests/zwo-firmware-tool.toml
@@ -20,7 +20,6 @@ elevation = true
 silent = "/S"
 
 [checkver]
-provider = "manual"
-
-[checkver.autoupdate]
+provider = "redirect"
 url = "https://dl.zwoastro.com/software?app=FirmwareUpgradeTool&platform=windows86&region=Overseas"
+regex = 'FWUpdate_Windows_v(\d+\.\d+\.\d+)\.'

--- a/manifests/zwo-native-driver.toml
+++ b/manifests/zwo-native-driver.toml
@@ -21,7 +21,6 @@ elevation = true
 silent = "/S"
 
 [checkver]
-provider = "manual"
-
-[checkver.autoupdate]
+provider = "redirect"
 url = "https://dl.zwoastro.com/software?app=AsiCameraDriver&platform=windows64&region=Overseas"
+regex = 'ASI_Cameras_driver_Setup_V(\d+\.\d+\.\d+(?:\.\d+)?)\.exe'


### PR DESCRIPTION
Switch zwo-asi-driver, zwo-firmware-tool, and zwo-native-driver from manual to redirect provider. The previous PR (#106) added the redirect provider code but the manifest changes were lost in the squash merge conflict with #105.
