### PR TITLE
feat: add download URL templates for remaining 33 packages

### DIFF
--- a/manifests/apt-app.toml
+++ b/manifests/apt-app.toml
@@ -23,3 +23,6 @@ silent = "/VERYSILENT /NORESTART /SUPPRESSMSGBOXES"
 provider = "html_scrape"
 url = "https://astrophotography.app/downloads.php"
 regex = 'UnReg(\d+_\d+(?:_\d+)?)\.exe'
+
+[checkver.autoupdate]
+url = "https://astrophotography.app/UnReg$version.exe"

--- a/manifests/astroasis-focuser-ascom.toml
+++ b/manifests/astroasis-focuser-ascom.toml
@@ -24,5 +24,8 @@ provider = "html_scrape"
 url = "https://www.astroasis.com/download/"
 regex = '_(\d+\.\d+\.\d+\.\d+)_'
 
+[checkver.autoupdate]
+url = "https://www.astroasis.com/download/files/focuser/Astroasis_Oasis_Focuser_ASCOM_$version_Setup.zip"
+
 [dependencies]
 requires = ["ascom-platform"]

--- a/manifests/astroasis-focuser-firmware.toml
+++ b/manifests/astroasis-focuser-firmware.toml
@@ -15,3 +15,6 @@ method = "zip_wrap"
 provider = "html_scrape"
 url = "https://www.astroasis.com/download/"
 regex = 'Ver_(\d+\.\d+\.\d+)'
+
+[checkver.autoupdate]
+url = "https://www.astroasis.com/download/files/focuser/Oasis_Focuser_Rose_Firmware_Ver_$version.zip"

--- a/manifests/astroasis-focuser-triple-ascom.toml
+++ b/manifests/astroasis-focuser-triple-ascom.toml
@@ -24,5 +24,8 @@ provider = "html_scrape"
 url = "https://www.astroasis.com/download/"
 regex = '_(\d+\.\d+\.\d+\.\d+)_'
 
+[checkver.autoupdate]
+url = "https://www.astroasis.com/download/files/focuser/Astroasis_Oasis_Focuser_Triplet_ASCOM_$version_Setup.zip"
+
 [dependencies]
 requires = ["ascom-platform"]

--- a/manifests/astroasis-fw-ascom.toml
+++ b/manifests/astroasis-fw-ascom.toml
@@ -24,5 +24,8 @@ provider = "html_scrape"
 url = "https://www.astroasis.com/download/"
 regex = '_(\d+\.\d+\.\d+\.\d+)_'
 
+[checkver.autoupdate]
+url = "https://www.astroasis.com/download/files/filterwheel/Astroasis_Oasis_Filter_Wheel_ASCOM_$version_Setup.zip"
+
 [dependencies]
 requires = ["ascom-platform"]

--- a/manifests/astroasis-fw-firmware.toml
+++ b/manifests/astroasis-fw-firmware.toml
@@ -15,3 +15,6 @@ method = "zip_wrap"
 provider = "html_scrape"
 url = "https://www.astroasis.com/download/"
 regex = 'Ver_(\d+\.\d+\.\d+)'
+
+[checkver.autoupdate]
+url = "https://www.astroasis.com/download/files/filterwheel/Oasis_Filter_Wheel_Firmware_Ver_$version.zip"

--- a/manifests/atik-core-software.toml
+++ b/manifests/atik-core-software.toml
@@ -25,5 +25,8 @@ provider = "html_scrape"
 url = "https://www.atik-cameras.com/software-downloads/"
 regex = 'Universal-(\d{4}\.\d{2}\.\d{2})\.exe'
 
+[checkver.autoupdate]
+url = "https://downloads.atik-cameras.com/Universal-$version.exe"
+
 [dependencies]
 requires = ["ascom-platform"]

--- a/manifests/celestron-cfm.toml
+++ b/manifests/celestron-cfm.toml
@@ -18,3 +18,6 @@ method = "zip_wrap"
 provider = "html_scrape"
 url = "https://software.celestron.com/updates/CFM/CFM/release.json"
 regex = '"version"\s*:\s*"([\d.]+)"'
+
+[checkver.autoupdate]
+url = "https://software.celestron.com/updates/CFM/CFM/CFM_$version_windows_x86.zip"

--- a/manifests/firecapture-app.toml
+++ b/manifests/firecapture-app.toml
@@ -23,3 +23,6 @@ silent = "/S"
 provider = "html_scrape"
 url = "https://www.firecapture.de"
 regex = 'FireCapture_v(\d+\.\d+\.\d+)\.zip'
+
+[checkver.autoupdate]
+url = "http://www.firecapture.de/download.php?file=FireCapture_v$version.zip"

--- a/manifests/lunatico-cloudwatcher-firmware.toml
+++ b/manifests/lunatico-cloudwatcher-firmware.toml
@@ -16,3 +16,6 @@ elevation = true
 provider = "html_scrape"
 url = "https://lunaticoastro.com/aag-cloud-watcher/software-other-downloads/"
 regex = 'CloudWatcher(\d+)\.has'
+
+[checkver.autoupdate]
+url = "https://lunaticoastro.com/aagcw/AAG_CloudWatcher$version.has"

--- a/manifests/moonlite-nitecrawler-ascom.toml
+++ b/manifests/moonlite-nitecrawler-ascom.toml
@@ -19,5 +19,8 @@ provider = "html_scrape"
 url = "https://focuser.com/downloads.php"
 regex = 'NiteCrawler\s+Setup\s+(\d+\.\d+\.\d+)'
 
+[checkver.autoupdate]
+url = "https://focuser.com/media/Downloads/NiteCrawler/Ascom/NiteCrawler%20Setup%20$version.zip"
+
 [dependencies]
 requires = ["ascom-platform"]

--- a/manifests/moonlite-nitecrawler-control.toml
+++ b/manifests/moonlite-nitecrawler-control.toml
@@ -18,3 +18,6 @@ method = "zip_wrap"
 provider = "html_scrape"
 url = "https://focuser.com/downloads.php"
 regex = 'NC_Remote_(\d+_\d+_\d+)\.zip'
+
+[checkver.autoupdate]
+url = "https://focuser.com/media/Downloads/NiteCrawler/NonAscom/NC_Remote_$version.zip"

--- a/manifests/moonlite-single-focuser.toml
+++ b/manifests/moonlite-single-focuser.toml
@@ -18,3 +18,6 @@ method = "zip_wrap"
 provider = "html_scrape"
 url = "https://focuser.com/downloads.php"
 regex = '_v(\d+\.\d+)\.zip'
+
+[checkver.autoupdate]
+url = "https://focuser.com/media/Downloads/MoonLite_Software/NonAscom/MoonliteSingleFocuser_v$version.zip"

--- a/manifests/player-one-camera-ascom.toml
+++ b/manifests/player-one-camera-ascom.toml
@@ -20,5 +20,8 @@ provider = "html_scrape"
 url = "https://player-one-astronomy.com/service/software/"
 regex = '_V(\d+\.\d+\.\d+\.\d+)\.'
 
+[checkver.autoupdate]
+url = "https://player-one-astronomy.com/service/download/PlayerOne_Camera_ASCOM_V$version.zip"
+
 [dependencies]
 requires = ["ascom-platform", "player-one-native-driver"]

--- a/manifests/player-one-directshow.toml
+++ b/manifests/player-one-directshow.toml
@@ -19,3 +19,6 @@ method = "zip_wrap"
 provider = "html_scrape"
 url = "https://player-one-astronomy.com/service/software/"
 regex = '_V(\d+\.\d+\.\d+\.\d+)\.'
+
+[checkver.autoupdate]
+url = "https://player-one-astronomy.com/service/download/PlayerOne_DirectShow_V$version.zip"

--- a/manifests/player-one-fw-ascom.toml
+++ b/manifests/player-one-fw-ascom.toml
@@ -20,5 +20,8 @@ provider = "html_scrape"
 url = "https://player-one-astronomy.com/service/software/"
 regex = '_V(\d+\.\d+\.\d+\.\d+)\.'
 
+[checkver.autoupdate]
+url = "https://player-one-astronomy.com/service/download/PlayerOne_FilterWheel_ASCOM_V$version.zip"
+
 [dependencies]
 requires = ["ascom-platform"]

--- a/manifests/player-one-native-driver.toml
+++ b/manifests/player-one-native-driver.toml
@@ -20,3 +20,6 @@ method = "zip_wrap"
 provider = "html_scrape"
 url = "https://player-one-astronomy.com/service/software/"
 regex = '_V(\d+\.\d+\.\d+\.\d+)\.'
+
+[checkver.autoupdate]
+url = "https://player-one-astronomy.com/service/download/PlayerOne_Camera_Driver_V$version.exe"

--- a/manifests/qhy-polemaster.toml
+++ b/manifests/qhy-polemaster.toml
@@ -19,3 +19,6 @@ method = "zip_wrap"
 provider = "html_scrape"
 url = "https://www.qhyccd.com/download/"
 regex = '_V(\d+\.\d+\.\d+\.\d+)\.'
+
+[checkver.autoupdate]
+url = "https://www.qhyccd.com/file/repository/PoleMaster/PoleMaster_V$version.zip"

--- a/manifests/qhy-qfocuser.toml
+++ b/manifests/qhy-qfocuser.toml
@@ -24,5 +24,8 @@ provider = "html_scrape"
 url = "https://www.qhyccd.com/download/"
 regex = '-V(\d+\.\d+\.\d+\.\d+)\.'
 
+[checkver.autoupdate]
+url = "https://www.qhyccd.com/file/repository/QFocuser/QFocuser-V$version.exe"
+
 [dependencies]
 requires = ["ascom-platform"]

--- a/manifests/synscan-app-ascom.toml
+++ b/manifests/synscan-app-ascom.toml
@@ -23,5 +23,8 @@ provider = "html_scrape"
 url = "https://www.skywatcher.com/download/software/ascom-driver/"
 regex = 'Version (\d+\.\d+\.\d+)'
 
+[checkver.autoupdate]
+url = "https://inter-static.skywatcher.com/downloads/setup_synscan_app_ascom_driver_$cleanVersion.exe"
+
 [dependencies]
 requires = ["ascom-platform"]

--- a/manifests/synscan-firmware-loader-wifi.toml
+++ b/manifests/synscan-firmware-loader-wifi.toml
@@ -19,3 +19,6 @@ provider = "html_scrape"
 url = "https://www.skywatcher.com/download/software/motor-control-firmware/"
 regex = 'Motor Controller Firmware Loader - WiFi, Version (\d+\.\d+)'
 css_selector = ".list-page-object-name"
+
+[checkver.autoupdate]
+url = "https://inter-static.skywatcher.com/downloads/mcfirmwareloader_wifi_$cleanVersion.zip"

--- a/manifests/synscan-firmware-loader.toml
+++ b/manifests/synscan-firmware-loader.toml
@@ -19,3 +19,6 @@ provider = "html_scrape"
 url = "https://www.skywatcher.com/download/software/motor-control-firmware/"
 regex = 'Motor Controller Firmware Loader, Version (\d+\.\d+)'
 css_selector = ".list-page-object-name"
+
+[checkver.autoupdate]
+url = "https://inter-static.skywatcher.com/downloads/mcfirmwareloader_$cleanVersion.zip"

--- a/manifests/synscan-hc-firmware.toml
+++ b/manifests/synscan-hc-firmware.toml
@@ -16,3 +16,6 @@ elevation = true
 provider = "html_scrape"
 url = "https://www.skywatcher.com/download/software/synscan-v4-hand-controller-firmware/"
 regex = 'Version (\d+\.\d+\.\d+)'
+
+[checkver.autoupdate]
+url = "https://inter-static.skywatcher.com/downloads/synscan_hand_controller_firmware_v$underscoreVersion_release.zip"

--- a/manifests/synscan-mc014-firmware.toml
+++ b/manifests/synscan-mc014-firmware.toml
@@ -16,3 +16,6 @@ elevation = true
 provider = "html_scrape"
 url = "https://www.skywatcher.com/download/software/motor-control-firmware/"
 regex = 'Version (\d+\.\d+)'
+
+[checkver.autoupdate]
+url = "https://inter-static.skywatcher.com/downloads/mc014_1_motor_controller_firmware_standard_0$cleanVersion.zip"

--- a/manifests/synscan-mc015-firmware.toml
+++ b/manifests/synscan-mc015-firmware.toml
@@ -16,3 +16,6 @@ elevation = true
 provider = "html_scrape"
 url = "https://www.skywatcher.com/download/software/motor-control-firmware/"
 regex = 'Version (\d+\.\d+)'
+
+[checkver.autoupdate]
+url = "https://inter-static.skywatcher.com/downloads/mc015_firmware_v0$cleanVersion.zip"

--- a/manifests/synscan-mc016-firmware.toml
+++ b/manifests/synscan-mc016-firmware.toml
@@ -16,3 +16,6 @@ elevation = true
 provider = "html_scrape"
 url = "https://www.skywatcher.com/download/software/motor-control-firmware/"
 regex = 'Ver\.(\d+\.\d+)'
+
+[checkver.autoupdate]
+url = "https://inter-static.skywatcher.com/downloads/mc016_ver0$cleanVersion.zip"

--- a/manifests/synscan-mc019-firmware.toml
+++ b/manifests/synscan-mc019-firmware.toml
@@ -16,3 +16,6 @@ elevation = true
 provider = "html_scrape"
 url = "https://www.skywatcher.com/download/software/motor-control-firmware/"
 regex = 'version (\d+\.\d+)'
+
+[checkver.autoupdate]
+url = "https://inter-static.skywatcher.com/downloads/mc019_firmware_v0$cleanVersion.zip"

--- a/manifests/synscan-mc020-firmware.toml
+++ b/manifests/synscan-mc020-firmware.toml
@@ -16,3 +16,6 @@ elevation = true
 provider = "html_scrape"
 url = "https://www.skywatcher.com/download/software/motor-control-firmware/"
 regex = 'version (\d+\.\d+)'
+
+[checkver.autoupdate]
+url = "https://inter-static.skywatcher.com/downloads/mc020_firmware_0$cleanVersion.zip"

--- a/manifests/synscan-mc021-firmware.toml
+++ b/manifests/synscan-mc021-firmware.toml
@@ -16,3 +16,6 @@ elevation = true
 provider = "html_scrape"
 url = "https://www.skywatcher.com/download/software/motor-control-firmware/"
 regex = 'version (\d+\.\d+)'
+
+[checkver.autoupdate]
+url = "https://inter-static.skywatcher.com/downloads/mc021_motor_controller_firmware_0$cleanVersion.zip"

--- a/manifests/synscan-mc029-firmware.toml
+++ b/manifests/synscan-mc029-firmware.toml
@@ -16,3 +16,6 @@ elevation = true
 provider = "html_scrape"
 url = "https://www.skywatcher.com/download/software/motor-control-firmware/"
 regex = 'version (\d+\.\d+)'
+
+[checkver.autoupdate]
+url = "https://inter-static.skywatcher.com/downloads/mc029_ver0$cleanVersion.zip"

--- a/manifests/synscan-mc030-firmware.toml
+++ b/manifests/synscan-mc030-firmware.toml
@@ -16,3 +16,6 @@ elevation = true
 provider = "html_scrape"
 url = "https://www.skywatcher.com/download/software/motor-control-firmware/"
 regex = 'Version (\d+\.\d+)'
+
+[checkver.autoupdate]
+url = "https://inter-static.skywatcher.com/downloads/mc030_ver0$cleanVersion.zip"

--- a/manifests/synscan-pro-app.toml
+++ b/manifests/synscan-pro-app.toml
@@ -19,3 +19,6 @@ provider = "html_scrape"
 url = "https://www.skywatcher.com/download/software/synscan-app/"
 regex = 'SynScan Pro App, Version (\d+\.\d+\.\d+)'
 css_selector = ".list-page-object-name"
+
+[checkver.autoupdate]
+url = "https://inter-static.skywatcher.com/downloads/synscanpro_windows_$cleanVersion.zip"

--- a/manifests/synscan-wifi-firmware.toml
+++ b/manifests/synscan-wifi-firmware.toml
@@ -16,3 +16,6 @@ elevation = true
 provider = "html_scrape"
 url = "https://www.skywatcher.com/download/software/accessories/"
 regex = 'Version (\d+\.\d+)'
+
+[checkver.autoupdate]
+url = "https://inter-static.skywatcher.com/downloads/synscan_wi-fi_adapter_firmware_version_$cleanVersion.zip"


### PR DESCRIPTION
## Summary
Add `[checkver.autoupdate]` download URL templates to the remaining 33 packages:
- SynScan/Sky-Watcher (14), Player One (4), Astroasis (5), QHY (2), MoonLite (3), and 5 individual packages

After this, all 96 packages have a download URL mechanism: 89 via autoupdate templates, 5 via redirect provider (ZWO), 2 via GitHub API.

## Test plan
- [ ] CI passes
- [ ] After merge + pipeline, all packages should have download URLs in catalog
