### PR TITLE
fix: switch eqmod-app from pe_download to html_scrape

### DIFF
--- a/manifests/eqmod-app.toml
+++ b/manifests/eqmod-app.toml
@@ -21,11 +21,12 @@ elevation = true
 silent = "/S"
 
 [checkver]
-provider = "pe_download"
-url = "https://sourceforge.net/projects/eq-mod/files/EQASCOM/EQASCOM_V200w_Setup.exe/download"
+provider = "html_scrape"
+url = "https://sourceforge.net/projects/eq-mod/files/EQASCOM/"
+regex = 'EQASCOM_V(\d+\w+)_Setup\.exe'
 
 [checkver.autoupdate]
-url = "https://sourceforge.net/projects/eq-mod/files/EQASCOM/EQASCOM_V200w_Setup.exe/download"
+url = "https://sourceforge.net/projects/eq-mod/files/EQASCOM/EQASCOM_V$version_Setup.exe/download"
 
 [dependencies]
 requires = ["ascom-platform"]


### PR DESCRIPTION
## Summary
- Switch eqmod-app from pe_download to html_scrape provider
- PE download fails with 'address misaligned' due to SourceForge bot detection
- Now scrapes SourceForge file listing page for version in filename pattern (V200w)
- Autoupdate URL template uses extracted version

Fixes #109