### PR TITLE
feat: add structured reminders for manual-check packages

### DIFF
--- a/crates/checker/src/issue.rs
+++ b/crates/checker/src/issue.rs
@@ -1,3 +1,4 @@
+use astro_up_shared::manifest::Manifest;
 use astro_up_shared::state::CheckerState;
 use reqwest_middleware::ClientWithMiddleware;
 
@@ -139,6 +140,142 @@ async fn close_issue(
     let payload = serde_json::to_vec(&serde_json::json!({
         "state": "closed",
         "state_reason": "completed"
+    }))?;
+    let resp = client
+        .patch(&url)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("Content-Type", "application/json")
+        .body(payload)
+        .send()
+        .await?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        anyhow::bail!("GitHub API returned {status}: {text}");
+    }
+
+    Ok(())
+}
+
+/// Create or update a GitHub issue that reminds maintainers to review manual-check packages.
+/// Requires `GITHUB_TOKEN` and `GITHUB_REPOSITORY` env vars. Silently skips if either is unset.
+pub async fn process_manual_reminders(
+    state: &mut CheckerState,
+    manifests: &[Manifest],
+    client: &ClientWithMiddleware,
+) -> anyhow::Result<()> {
+    let token = match std::env::var("GITHUB_TOKEN") {
+        Ok(t) => t,
+        Err(_) => return Ok(()),
+    };
+    let repo = match std::env::var("GITHUB_REPOSITORY") {
+        Ok(r) => r,
+        Err(_) => return Ok(()),
+    };
+
+    // Find all manual-check packages
+    let manual_packages: Vec<&Manifest> = manifests
+        .iter()
+        .filter(|m| m.checkver.as_ref().is_some_and(|cv| cv.provider == "manual"))
+        .collect();
+
+    if manual_packages.is_empty() {
+        return Ok(());
+    }
+
+    // Build markdown table
+    let now = chrono::Utc::now();
+    let mut body = String::from(
+        "The following packages use manual version checking and may need review:\n\n\
+         | Package | Last Updated | Days Since Update |\n\
+         |---------|-------------|-------------------|\n",
+    );
+
+    for m in &manual_packages {
+        let last_update = state
+            .manifests
+            .get(&m.id)
+            .and_then(|ms| ms.last_manual_update);
+        let days = last_update.map(|t| (now - t).num_days()).unwrap_or(-1);
+        let days_str = if days < 0 {
+            "never".to_string()
+        } else {
+            format!("{days}")
+        };
+        let date_str = last_update
+            .map(|t| t.format("%Y-%m-%d").to_string())
+            .unwrap_or_else(|| "never".to_string());
+        body.push_str(&format!("| {} | {} | {} |\n", m.id, date_str, days_str));
+    }
+
+    body.push_str("\n*This issue is auto-updated by the checker pipeline.*");
+
+    let title = "Manual version check reminder";
+
+    if let Some(issue_num) = state.manual_reminder_issue {
+        // Update existing issue
+        update_issue(&token, &repo, issue_num, &body, client).await?;
+        tracing::info!("updated manual reminder issue #{issue_num}");
+    } else {
+        // Create new issue
+        let number = create_reminder_issue(&token, &repo, title, &body, client).await?;
+        state.manual_reminder_issue = Some(number);
+        tracing::info!("created manual reminder issue #{number}");
+    }
+
+    Ok(())
+}
+
+async fn create_reminder_issue(
+    token: &str,
+    repo: &str,
+    title: &str,
+    body: &str,
+    client: &ClientWithMiddleware,
+) -> anyhow::Result<u64> {
+    let url = format!("https://api.github.com/repos/{repo}/issues");
+    let payload = serde_json::to_vec(&serde_json::json!({
+        "title": title,
+        "body": body,
+        "labels": ["manual-check"]
+    }))?;
+    let resp = client
+        .post(&url)
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("Content-Type", "application/json")
+        .body(payload)
+        .send()
+        .await?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        anyhow::bail!("GitHub API returned {status}: {text}");
+    }
+
+    let json: serde_json::Value = resp.json().await?;
+    let number = json["number"]
+        .as_u64()
+        .ok_or_else(|| anyhow::anyhow!("missing issue number in response"))?;
+
+    Ok(number)
+}
+
+async fn update_issue(
+    token: &str,
+    repo: &str,
+    number: u64,
+    body: &str,
+    client: &ClientWithMiddleware,
+) -> anyhow::Result<()> {
+    let url = format!("https://api.github.com/repos/{repo}/issues/{number}");
+    let payload = serde_json::to_vec(&serde_json::json!({
+        "body": body
     }))?;
     let resp = client
         .patch(&url)

--- a/crates/checker/src/main.rs
+++ b/crates/checker/src/main.rs
@@ -145,6 +145,13 @@ async fn main() -> anyhow::Result<()> {
         for (id, num) in &issue_report.closed {
             println!("  Issue closed: #{num} for {id}");
         }
+
+        astro_up_checker::issue::process_manual_reminders(
+            &mut state_guard,
+            &all_manifests,
+            &client,
+        )
+        .await?;
     }
 
     // 7. Write updated state
@@ -319,6 +326,13 @@ async fn process_manifest(
             }
 
             state.lock().await.record_success(&manifest.id);
+
+            if provider == "manual" {
+                let mut st = state.lock().await;
+                if let Some(ms) = st.manifests.get_mut(&manifest.id) {
+                    ms.last_manual_update = Some(chrono::Utc::now());
+                }
+            }
         }
         Ok(CheckOutcome::Skipped { reason }) => {
             tracing::debug!("{}: skipped — {reason}", manifest.id);

--- a/crates/shared/src/state.rs
+++ b/crates/shared/src/state.rs
@@ -12,11 +12,15 @@ pub struct ManifestState {
     pub last_error: Option<String>,
     #[serde(default)]
     pub issue_number: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_manual_update: Option<DateTime<Utc>>,
 }
 
 /// The full checker state file (`checker-state.json`).
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct CheckerState {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub manual_reminder_issue: Option<u64>,
     #[serde(flatten)]
     pub manifests: HashMap<String, ManifestState>,
 }
@@ -48,6 +52,7 @@ impl CheckerState {
                 last_checked: Utc::now(),
                 last_error: None,
                 issue_number: None,
+                last_manual_update: None,
             });
         entry.consecutive_failures = 0;
         entry.last_checked = Utc::now();
@@ -64,6 +69,7 @@ impl CheckerState {
                 last_checked: Utc::now(),
                 last_error: None,
                 issue_number: None,
+                last_manual_update: None,
             });
         entry.consecutive_failures += 1;
         entry.last_checked = Utc::now();


### PR DESCRIPTION
## Summary
- Add process_manual_reminders() to checker pipeline
- Creates/updates a single GitHub issue listing all manual-check packages with days since last update
- Tracks last_manual_update in checker state per manifest
- Uses 'manual-check' label for the reminder issue

Closes #7