### PR TITLE
feat: add ledger detection method to 22 firmware packages

### DIFF
--- a/manifests/astroasis-focuser-firmware.toml
+++ b/manifests/astroasis-focuser-firmware.toml
@@ -18,3 +18,6 @@ regex = 'Ver_(\d+\.\d+\.\d+)'
 
 [checkver.autoupdate]
 url = "https://www.astroasis.com/download/files/focuser/Oasis_Focuser_Rose_Firmware_Ver_$version.zip"
+
+[detection]
+method = "ledger"

--- a/manifests/astroasis-fw-firmware.toml
+++ b/manifests/astroasis-fw-firmware.toml
@@ -18,3 +18,6 @@ regex = 'Ver_(\d+\.\d+\.\d+)'
 
 [checkver.autoupdate]
 url = "https://www.astroasis.com/download/files/filterwheel/Oasis_Filter_Wheel_Firmware_Ver_$version.zip"
+
+[detection]
+method = "ledger"

--- a/manifests/ioptron-cem120-firmware.toml
+++ b/manifests/ioptron-cem120-firmware.toml
@@ -19,3 +19,6 @@ regex = 'FW(\d{6})'
 
 [checkver.autoupdate]
 url = "https://www.ioptron.com/v/firmware/CEM120_FW230305.bin"
+
+[detection]
+method = "ledger"

--- a/manifests/ioptron-cem26-firmware.toml
+++ b/manifests/ioptron-cem26-firmware.toml
@@ -19,3 +19,6 @@ regex = 'FW(\d{6})'
 
 [checkver.autoupdate]
 url = "https://www.ioptron.com/v/firmware/CEM26_GEM28_FW241201.bin"
+
+[detection]
+method = "ledger"

--- a/manifests/ioptron-cem40-firmware.toml
+++ b/manifests/ioptron-cem40-firmware.toml
@@ -19,3 +19,6 @@ regex = 'FW(\d{6})'
 
 [checkver.autoupdate]
 url = "https://www.ioptron.com/v/firmware/CEM40_GEM45_FW230305.bin"
+
+[detection]
+method = "ledger"

--- a/manifests/ioptron-cem70-firmware.toml
+++ b/manifests/ioptron-cem70-firmware.toml
@@ -19,3 +19,6 @@ regex = 'FW(\d{6})'
 
 [checkver.autoupdate]
 url = "https://www.ioptron.com/v/firmware/CEM70_FW230305.bin"
+
+[detection]
+method = "ledger"

--- a/manifests/ioptron-hae-bc-firmware.toml
+++ b/manifests/ioptron-hae-bc-firmware.toml
@@ -19,3 +19,6 @@ regex = 'FW(\d{6})'
 
 [checkver.autoupdate]
 url = "https://www.ioptron.com/v/firmware/HAEbc_FW241201.bin"
+
+[detection]
+method = "ledger"

--- a/manifests/ioptron-hae-firmware.toml
+++ b/manifests/ioptron-hae-firmware.toml
@@ -19,3 +19,6 @@ regex = 'FW(\d{6})'
 
 [checkver.autoupdate]
 url = "https://www.ioptron.com/v/firmware/HAE_FW241201.bin"
+
+[detection]
+method = "ledger"

--- a/manifests/ioptron-haz-firmware.toml
+++ b/manifests/ioptron-haz-firmware.toml
@@ -19,3 +19,6 @@ regex = 'FW(\d{6})'
 
 [checkver.autoupdate]
 url = "https://www.ioptron.com/v/firmware/HAZ_FW240121.bin"
+
+[detection]
+method = "ledger"

--- a/manifests/ioptron-hem-firmware.toml
+++ b/manifests/ioptron-hem-firmware.toml
@@ -19,3 +19,6 @@ regex = 'FW(\d{6})'
 
 [checkver.autoupdate]
 url = "https://www.ioptron.com/v/firmware/HEM_FW241201.bin"
+
+[detection]
+method = "ledger"

--- a/manifests/losmandy-gemini-firmware.toml
+++ b/manifests/losmandy-gemini-firmware.toml
@@ -17,3 +17,6 @@ provider = "manual"
 
 [checkver.autoupdate]
 url = "https://gemini-2.com/firmware1/combined.zip"
+
+[detection]
+method = "ledger"

--- a/manifests/lunatico-cloudwatcher-firmware.toml
+++ b/manifests/lunatico-cloudwatcher-firmware.toml
@@ -19,3 +19,6 @@ regex = 'CloudWatcher(\d+)\.has'
 
 [checkver.autoupdate]
 url = "https://lunaticoastro.com/aagcw/AAG_CloudWatcher$version.has"
+
+[detection]
+method = "ledger"

--- a/manifests/synscan-hc-firmware.toml
+++ b/manifests/synscan-hc-firmware.toml
@@ -19,3 +19,6 @@ regex = 'Version (\d+\.\d+\.\d+)'
 
 [checkver.autoupdate]
 url = "https://inter-static.skywatcher.com/downloads/synscan_hand_controller_firmware_v$underscoreVersion_release.zip"
+
+[detection]
+method = "ledger"

--- a/manifests/synscan-mc014-firmware.toml
+++ b/manifests/synscan-mc014-firmware.toml
@@ -19,3 +19,6 @@ regex = 'Version (\d+\.\d+)'
 
 [checkver.autoupdate]
 url = "https://inter-static.skywatcher.com/downloads/mc014_1_motor_controller_firmware_standard_0$cleanVersion.zip"
+
+[detection]
+method = "ledger"

--- a/manifests/synscan-mc015-firmware.toml
+++ b/manifests/synscan-mc015-firmware.toml
@@ -19,3 +19,6 @@ regex = 'Version (\d+\.\d+)'
 
 [checkver.autoupdate]
 url = "https://inter-static.skywatcher.com/downloads/mc015_firmware_v0$cleanVersion.zip"
+
+[detection]
+method = "ledger"

--- a/manifests/synscan-mc016-firmware.toml
+++ b/manifests/synscan-mc016-firmware.toml
@@ -19,3 +19,6 @@ regex = 'Ver\.(\d+\.\d+)'
 
 [checkver.autoupdate]
 url = "https://inter-static.skywatcher.com/downloads/mc016_ver0$cleanVersion.zip"
+
+[detection]
+method = "ledger"

--- a/manifests/synscan-mc019-firmware.toml
+++ b/manifests/synscan-mc019-firmware.toml
@@ -19,3 +19,6 @@ regex = 'version (\d+\.\d+)'
 
 [checkver.autoupdate]
 url = "https://inter-static.skywatcher.com/downloads/mc019_firmware_v0$cleanVersion.zip"
+
+[detection]
+method = "ledger"

--- a/manifests/synscan-mc020-firmware.toml
+++ b/manifests/synscan-mc020-firmware.toml
@@ -19,3 +19,6 @@ regex = 'version (\d+\.\d+)'
 
 [checkver.autoupdate]
 url = "https://inter-static.skywatcher.com/downloads/mc020_firmware_0$cleanVersion.zip"
+
+[detection]
+method = "ledger"

--- a/manifests/synscan-mc021-firmware.toml
+++ b/manifests/synscan-mc021-firmware.toml
@@ -19,3 +19,6 @@ regex = 'version (\d+\.\d+)'
 
 [checkver.autoupdate]
 url = "https://inter-static.skywatcher.com/downloads/mc021_motor_controller_firmware_0$cleanVersion.zip"
+
+[detection]
+method = "ledger"

--- a/manifests/synscan-mc029-firmware.toml
+++ b/manifests/synscan-mc029-firmware.toml
@@ -19,3 +19,6 @@ regex = 'version (\d+\.\d+)'
 
 [checkver.autoupdate]
 url = "https://inter-static.skywatcher.com/downloads/mc029_ver0$cleanVersion.zip"
+
+[detection]
+method = "ledger"

--- a/manifests/synscan-mc030-firmware.toml
+++ b/manifests/synscan-mc030-firmware.toml
@@ -19,3 +19,6 @@ regex = 'Version (\d+\.\d+)'
 
 [checkver.autoupdate]
 url = "https://inter-static.skywatcher.com/downloads/mc030_ver0$cleanVersion.zip"
+
+[detection]
+method = "ledger"

--- a/manifests/synscan-wifi-firmware.toml
+++ b/manifests/synscan-wifi-firmware.toml
@@ -19,3 +19,6 @@ regex = 'Version (\d+\.\d+)'
 
 [checkver.autoupdate]
 url = "https://inter-static.skywatcher.com/downloads/synscan_wi-fi_adapter_firmware_version_$cleanVersion.zip"
+
+[detection]
+method = "ledger"


### PR DESCRIPTION
Firmware packages are resource-type manifests that cannot be auto-detected through registry, PE analysis, or filesystem scanning. They are tracked exclusively through the ledger once manually acknowledged by the user.

This PR adds the required `[detection]` section with `method = "ledger"` to 22 firmware manifest files across Astroasis, iOptron, Losmandy, Lunatico, and Sky-Watcher products.

## Changed files
- 2x Astroasis firmware (focuser, filter wheel)
- 8x iOptron mount firmware (CEM120, CEM26, CEM40, CEM70, HAE, HAE-BC, HAZ, HEM)
- 1x Losmandy Gemini 2 firmware
- 1x Lunatico CloudWatcher firmware
- 10x SynScan firmware (hand controller, WiFi adapter, 8x motor controllers)
