### PR TITLE
feat: add backup config_paths to 8 application manifests

### DIFF
--- a/manifests/apt-app.toml
+++ b/manifests/apt-app.toml
@@ -22,6 +22,9 @@ regex = 'UnReg(\d+_\d+(?:_\d+)?)\.exe'
 [checkver.autoupdate]
 url = "https://astrophotography.app/APT_UnReg$version.exe"
 
+[backup]
+config_paths = ["$LOCALAPPDATA/Astro Photography Tool"]
+
 [detection]
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{81F5BD58-9631-4FA7-B85D-C9BA948CF785}_is1"

--- a/manifests/ascom-remote-app.toml
+++ b/manifests/ascom-remote-app.toml
@@ -22,6 +22,9 @@ repo = "ASCOMRemote"
 [checkver.autoupdate]
 asset_filter = "\\.exe$"
 
+[backup]
+config_paths = ["$LOCALAPPDATA/ASCOM/Platform"]
+
 [dependencies]
 requires = ["ascom-platform"]
 

--- a/manifests/astap-app.toml
+++ b/manifests/astap-app.toml
@@ -23,6 +23,9 @@ regex = '\(v(\d{4}\.\d{2}\.\d{2})\)'
 url = "https://sourceforge.net/projects/astap-program/files/windows_installer/astap_setup.exe/download"
 skip_browser_ua = true
 
+[backup]
+config_paths = ["$LOCALAPPDATA/astap"]
+
 [detection]
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\AppName=ASTAP, the Astrometric STAcking Program,~D52A8A79_is1"

--- a/manifests/green-swamp-server-app.toml
+++ b/manifests/green-swamp-server-app.toml
@@ -23,6 +23,9 @@ repo = "GSServer"
 url = "https://github.com/rmorgan001/GSServer/releases/download/v$version/GreenSwampServer-$version-Setup.exe"
 asset_filter = "\\.exe$"
 
+[backup]
+config_paths = ["$LOCALAPPDATA/GS_Server"]
+
 [detection]
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{0ff78bd6-6149-4536-9252-3da68b94f7c2}_is1"

--- a/manifests/phd2-app.toml
+++ b/manifests/phd2-app.toml
@@ -22,6 +22,9 @@ repo = "phd2"
 [checkver.autoupdate]
 url = "https://openphdguiding.org/phd2-$version-installer.exe"
 
+[backup]
+config_paths = ["$LOCALAPPDATA/phd2/darks_defects", "$DOCUMENTS/PHD2"]
+
 [detection]
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\PHD 2_is1"

--- a/manifests/sharpcap-app.toml
+++ b/manifests/sharpcap-app.toml
@@ -25,6 +25,9 @@ resolver = "sharpcap"
 [checkver.autoupdate.resolver_args]
 arch = "x64"
 
+[backup]
+config_paths = ["$APPDATA/SharpCap"]
+
 [detection]
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{881672E1-F0EA-445C-89ED-78B74013DED2}"

--- a/manifests/stellarium-app.toml
+++ b/manifests/stellarium-app.toml
@@ -23,6 +23,9 @@ repo = "stellarium"
 url = "https://github.com/Stellarium/stellarium/releases/download/v$version/stellarium-$version-qt6-win64.exe"
 asset_filter = "qt6-win64\\.exe$"
 
+[backup]
+config_paths = ["$APPDATA/Stellarium"]
+
 [detection]
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Stellarium"

--- a/manifests/zwo-asistudio.toml
+++ b/manifests/zwo-asistudio.toml
@@ -8,6 +8,9 @@ category = "capture"
 type = "application"
 slug = "zwo-asistudio"
 
+[backup]
+config_paths = ["$LOCALAPPDATA/ZWO"]
+
 [detection]
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\ZWO\\ASIStudio"


### PR DESCRIPTION
## Summary

Add verified backup config_paths to 8 application manifests:

- **PHD2**: darks/defects maps + guide logs/camera frames
- **SharpCap**: capture profiles, sensor characteristics, sessions
- **Stellarium**: config.ini, custom objects, modules
- **ASTAP**: solver settings
- **ZWO ASIStudio**: camera gain/offset/USB config
- **ASCOM Remote**: platform/driver connection config
- **Green Swamp Server**: user.config (mount settings, site location)
- **APT**: equipment profiles (unverified, not installed on test machine)

All paths verified via SSH on the Windows test machine except APT.

## Test plan

- [ ] Compile catalog with updated manifests
- [ ] Verify backup paths resolve correctly on Windows
- [ ] NINA backup still works (existing config unchanged)
