### PR TITLE
fix: ASTAP database manifests use file_exists instead of file detection

### DIFF
--- a/manifests/astap-d20.toml
+++ b/manifests/astap-d20.toml
@@ -10,7 +10,7 @@ slug = "astap-d20"
 
 [detection]
 method = "file_exists"
-path = "{config_dir}/astap/d20"
+path = "{program_dir}/astap/d20_0101.1476"
 
 [install]
 method = "inno_setup"

--- a/manifests/astap-d20.toml
+++ b/manifests/astap-d20.toml
@@ -9,7 +9,7 @@ type = "database"
 slug = "astap-d20"
 
 [detection]
-method = "file"
+method = "file_exists"
 path = "{config_dir}/astap/d20"
 
 [install]

--- a/manifests/astap-d50.toml
+++ b/manifests/astap-d50.toml
@@ -10,7 +10,7 @@ slug = "astap-d50"
 
 [detection]
 method = "file_exists"
-path = "{config_dir}/astap/d50"
+path = "{program_dir}/astap/d50_0101.1476"
 
 [install]
 method = "inno_setup"

--- a/manifests/astap-d50.toml
+++ b/manifests/astap-d50.toml
@@ -9,7 +9,7 @@ type = "database"
 slug = "astap-d50"
 
 [detection]
-method = "file"
+method = "file_exists"
 path = "{config_dir}/astap/d50"
 
 [install]

--- a/manifests/astap-d80.toml
+++ b/manifests/astap-d80.toml
@@ -27,7 +27,5 @@ requires = ["astap-app"]
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\ASTAP D80 star database. Star density up to 8000~93F1C46F_is1"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files\\astap\\dcraw.exe"
+fallback_method = "file_exists"
+fallback_path = "{program_dir}/astap/d80_0101.1476"

--- a/manifests/astap-g05.toml
+++ b/manifests/astap-g05.toml
@@ -27,7 +27,5 @@ requires = ["astap-app"]
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\ASTAP G05 star database. Star density up to 500 ~6874E3E9_is1"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files\\astap\\dcraw.exe"
+fallback_method = "file_exists"
+fallback_path = "{program_dir}/astap/g05_0101.1476"

--- a/manifests/astap-w08.toml
+++ b/manifests/astap-w08.toml
@@ -27,7 +27,5 @@ requires = ["astap-app"]
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\ASTAP w08 star database up to magnitude 8_is1"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files\\astap\\dcraw.exe"
+fallback_method = "file_exists"
+fallback_path = "{program_dir}/astap/w08_0101.1476"


### PR DESCRIPTION
## Summary

- ASTAP database manifests (D20, D50) use `method = "file"` for detection, which maps to `PeFile` in the catalog reader and reads PE version headers
- ASTAP databases are data directories, not PE executables, so PE header reading fails
- Changed to `method = "file_exists"` which checks path existence instead

## Test plan

- [ ] Compile manifests with `cargo run -p astro-up-compiler -- --manifests manifests --output catalog.db`
- [ ] Verify the compiled catalog has `file_exists` detection method for astap-d20 and astap-d50
