### PR TITLE
fix: detection fallback uses flat TOML syntax matching struct fields

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -3,3 +3,4 @@
 hae = "hae"
 # Lunatico Astronomia is the company's actual name
 astronomia = "astronomia"
+Astronomia = "Astronomia"

--- a/_typos.toml
+++ b/_typos.toml
@@ -2,3 +2,5 @@
 # Windows API: Plug and Play
 PnP = "PnP"
 Pn = "Pn"
+# Lunatico Astronomia is the company's actual name
+Astronomia = "Astronomia"

--- a/manifests/apt-app.toml
+++ b/manifests/apt-app.toml
@@ -26,7 +26,5 @@ url = "https://astrophotography.app/APT_UnReg$version.exe"
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{81F5BD58-9631-4FA7-B85D-C9BA948CF785}_is1"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Astro Photography Tool - APT\\APT.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Astro Photography Tool - APT\\APT.exe"

--- a/manifests/ascom-platform.toml
+++ b/manifests/ascom-platform.toml
@@ -26,7 +26,5 @@ asset_filter = "\\.exe$"
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\ASCOM Platform 7.1 Update 3"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\ASCOM\\Platform\\Tools\\ASCOM Diagnostics.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\ASCOM\\Platform\\Tools\\ASCOM Diagnostics.exe"

--- a/manifests/ascom-remote-app.toml
+++ b/manifests/ascom-remote-app.toml
@@ -29,7 +29,5 @@ requires = ["ascom-platform"]
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{0ee690ae-7927-4ee7-b851-f5877c077ff5}_is1"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files\\ASCOM\\RemoteServer\\RemoteServer.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files\\ASCOM\\RemoteServer\\RemoteServer.exe"

--- a/manifests/astap-app.toml
+++ b/manifests/astap-app.toml
@@ -27,7 +27,5 @@ skip_browser_ua = true
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\AppName=ASTAP, the Astrometric STAcking Program,~D52A8A79_is1"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files\\astap\\astap.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files\\astap\\astap.exe"

--- a/manifests/astap-d80.toml
+++ b/manifests/astap-d80.toml
@@ -27,7 +27,5 @@ requires = ["astap-app"]
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\ASTAP D80 star database. Star density up to 8000~93F1C46F_is1"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files\\astap\\dcraw.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files\\astap\\dcraw.exe"

--- a/manifests/astap-g05.toml
+++ b/manifests/astap-g05.toml
@@ -27,7 +27,5 @@ requires = ["astap-app"]
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\ASTAP G05 star database. Star density up to 500 ~6874E3E9_is1"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files\\astap\\dcraw.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files\\astap\\dcraw.exe"

--- a/manifests/astap-w08.toml
+++ b/manifests/astap-w08.toml
@@ -27,7 +27,5 @@ requires = ["astap-app"]
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\ASTAP w08 star database up to magnitude 8_is1"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files\\astap\\dcraw.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files\\astap\\dcraw.exe"

--- a/manifests/celestron-cfm.toml
+++ b/manifests/celestron-cfm.toml
@@ -24,7 +24,5 @@ url = "https://software.celestron.com/updates/CFM/CFM/CFM_$version_windows_x86.z
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{701FE845-D79C-35E9-8DB8-A0E2834B4BC5}"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files\\Celestron\\CelestronFirmwareManager.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files\\Celestron\\CelestronFirmwareManager.exe"

--- a/manifests/celestron-cpwi.toml
+++ b/manifests/celestron-cpwi.toml
@@ -26,7 +26,5 @@ url = "https://software.celestron.com/public_release/Setup_CPWI.exe"
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{ 632E8128-01D0-4A69-9D75-F5B8FA2EC0DB}_is1"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Celestron\\CPWI\\CPWI.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Celestron\\CPWI\\CPWI.exe"

--- a/manifests/celestron-focuser-usb-ascom.toml
+++ b/manifests/celestron-focuser-usb-ascom.toml
@@ -29,7 +29,5 @@ requires = ["ascom-platform"]
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{9f0d3fe4-c081-4f93-8706-999f57555dd5}_is1"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Focuser\\FocusSim.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Focuser\\FocusSim.exe"

--- a/manifests/green-swamp-server-app.toml
+++ b/manifests/green-swamp-server-app.toml
@@ -27,7 +27,5 @@ asset_filter = "\\.exe$"
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{0ff78bd6-6149-4536-9252-3da68b94f7c2}_is1"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Telescope\\GSServer\\GS.ChartViewer.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Telescope\\GSServer\\GS.ChartViewer.exe"

--- a/manifests/ioptron-ipolar.toml
+++ b/manifests/ioptron-ipolar.toml
@@ -26,7 +26,5 @@ url = "https://www.ioptron.com/v/firmware/3339_iOptron_iPolar.exe"
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{C15DDC0C-FC25-4CD5-9CA5-035014A4E6BB}_is1"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Users\\USER\\AppData\\Local\\iOptron iPolar\\iOptron iPolar.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Users\\USER\\AppData\\Local\\iOptron iPolar\\iOptron iPolar.exe"

--- a/manifests/lunatico-cloudwatcher-ascom.toml
+++ b/manifests/lunatico-cloudwatcher-ascom.toml
@@ -29,7 +29,5 @@ requires = ["ascom-platform"]
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\CloudWatcher ASCOM drivers_is1"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\CWAscom\\ASCOM.CloudWatcher.Server.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\CWAscom\\ASCOM.CloudWatcher.Server.exe"

--- a/manifests/lunatico-cloudwatcher-software.toml
+++ b/manifests/lunatico-cloudwatcher-software.toml
@@ -26,7 +26,5 @@ url = "https://lunaticoastro.com/aagcw/current/CWDataDisplay-Install.exe"
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\CloudWatcher Data Display_is1"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\CWDataDisplay\\CloudWatcherDataDisplay.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\CWDataDisplay\\CloudWatcherDataDisplay.exe"

--- a/manifests/lunatico-dragonfly.toml
+++ b/manifests/lunatico-dragonfly.toml
@@ -30,7 +30,5 @@ requires = ["ascom-platform"]
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Dragonfly Software_is1"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Dragonfly\\Dragonfly.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Dragonfly\\Dragonfly.exe"

--- a/manifests/moonlite-dro-ascom.toml
+++ b/manifests/moonlite-dro-ascom.toml
@@ -25,7 +25,5 @@ requires = ["ascom-platform"]
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{65bb1fc6-0e7c-4d60-bd4a-9003563baad6}_is1"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Focuser\\Moonlite\\ASCOM.Moonlite.Server.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Focuser\\Moonlite\\ASCOM.Moonlite.Server.exe"

--- a/manifests/moonlite-nitecrawler-ascom.toml
+++ b/manifests/moonlite-nitecrawler-ascom.toml
@@ -27,7 +27,5 @@ requires = ["ascom-platform"]
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{a4a31249-f8c9-4890-9dd5-7e6070270038}_is1"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Focuser\\NiteCrawler\\ASCOM.NiteCrawler.Server.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Focuser\\NiteCrawler\\ASCOM.NiteCrawler.Server.exe"

--- a/manifests/player-one-directshow.toml
+++ b/manifests/player-one-directshow.toml
@@ -24,7 +24,5 @@ url = "https://player-one-astronomy.com/download/softwares/DirectShow_PlayerOne_
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{AFFA9880-7881-4DB5-AD03-8FA3B369D39B}_is1"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\PlayerOneAstronomyDshow\\POACamService.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\PlayerOneAstronomyDshow\\POACamService.exe"

--- a/manifests/primaluce-alto.toml
+++ b/manifests/primaluce-alto.toml
@@ -24,7 +24,5 @@ url = "https://www.primalucelab.com/downloads/ALTO-software-package-1-4.zip"
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{6f22f133-5a31-4cd6-9e51-3ad456eeb98f}_is1"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\CoverCalibrator\\PLL\\ASCOM.Giotto.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\CoverCalibrator\\PLL\\ASCOM.Giotto.exe"

--- a/manifests/primaluce-arco.toml
+++ b/manifests/primaluce-arco.toml
@@ -24,7 +24,5 @@ url = "https://www.primalucelab.com/downloads/ARCO-software-package-3-7.zip"
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{a670a01f-e7af-49c9-aa67-b9fe518d7b35}_is1"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Focuser\\PLL\\ASCOM.ArcoEsatto.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Focuser\\PLL\\ASCOM.ArcoEsatto.exe"

--- a/manifests/primaluce-ecco2.toml
+++ b/manifests/primaluce-ecco2.toml
@@ -24,7 +24,5 @@ url = "https://www.primalucelab.com/downloads/ECCO2-software-package-3-2.zip"
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{66647901-73a4-43e1-960d-dd91aaf44438}_is1"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\ObservingConditions\\PLL\\ASCOM.ObCo_srv.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\ObservingConditions\\PLL\\ASCOM.ObCo_srv.exe"

--- a/manifests/primaluce-esatto.toml
+++ b/manifests/primaluce-esatto.toml
@@ -24,7 +24,5 @@ url = "https://www.primalucelab.com/downloads/ESATTO-software-package-3-7.zip"
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{a670a01f-e7af-49c9-aa67-b9fe518d7b35}_is1"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Focuser\\PLL\\ASCOM.ArcoEsatto.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Focuser\\PLL\\ASCOM.ArcoEsatto.exe"

--- a/manifests/primaluce-giotto.toml
+++ b/manifests/primaluce-giotto.toml
@@ -24,7 +24,5 @@ url = "https://www.primalucelab.com/downloads/GIOTTO-software-package-1-4.zip"
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{6f22f133-5a31-4cd6-9e51-3ad456eeb98f}_is1"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\CoverCalibrator\\PLL\\ASCOM.Giotto.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\CoverCalibrator\\PLL\\ASCOM.Giotto.exe"

--- a/manifests/primaluce-sesto-senso-2.toml
+++ b/manifests/primaluce-sesto-senso-2.toml
@@ -24,7 +24,5 @@ url = "https://www.primalucelab.com/downloads/SESTO-SENSO-2-software-package-3-7
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{a670a01f-e7af-49c9-aa67-b9fe518d7b35}_is1"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Focuser\\PLL\\ASCOM.ArcoEsatto.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Focuser\\PLL\\ASCOM.ArcoEsatto.exe"

--- a/manifests/primaluce-sesto-senso-3.toml
+++ b/manifests/primaluce-sesto-senso-3.toml
@@ -24,7 +24,5 @@ url = "https://www.primalucelab.com/downloads/SESTO-SENSO-3-software-package-1-0
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{a670a01f-e7af-49c9-aa67-b9fe518d7b35}_is1"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Focuser\\PLL\\ASCOM.ArcoEsatto.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Focuser\\PLL\\ASCOM.ArcoEsatto.exe"

--- a/manifests/qhy-allinone-beta.toml
+++ b/manifests/qhy-allinone-beta.toml
@@ -30,7 +30,5 @@ requires = ["ascom-platform"]
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{4BE2CEB1-D9AF-46F6-8410-C87F172A587D}_is1"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files\\QHYCCD\\AllInOne\\ascom\\QHYCCD-ASCOM-Platform6.5-V25.06.16.16.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files\\QHYCCD\\AllInOne\\ascom\\QHYCCD-ASCOM-Platform6.5-V25.06.16.16.exe"

--- a/manifests/qhy-allinone.toml
+++ b/manifests/qhy-allinone.toml
@@ -32,7 +32,5 @@ requires = ["ascom-platform"]
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{4BE2CEB1-D9AF-46F6-8410-C87F172A587D}_is1"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files\\QHYCCD\\AllInOne\\ascom\\QHYCCD-ASCOM-Platform6.5-V25.06.16.16.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files\\QHYCCD\\AllInOne\\ascom\\QHYCCD-ASCOM-Platform6.5-V25.06.16.16.exe"

--- a/manifests/qhy-polemaster.toml
+++ b/manifests/qhy-polemaster.toml
@@ -24,7 +24,5 @@ url = "https://www.qhyccd.com/file/repository/latestSoftAndDirver/Soft/PoleMaste
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{0552F2CD-F94D-43E0-9DC6-0008716B5112}_is1"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\QHYCCD\\PoleMaster_Qt\\PoleMaster_Qt\\PoleMaster.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\QHYCCD\\PoleMaster_Qt\\PoleMaster_Qt\\PoleMaster.exe"

--- a/manifests/sx-camera-ascom.toml
+++ b/manifests/sx-camera-ascom.toml
@@ -27,7 +27,5 @@ requires = ["ascom-platform"]
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\sxASCOM_is1"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Camera\\sxCamera\\ASCOM.sxCamera.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Camera\\sxCamera\\ASCOM.sxCamera.exe"

--- a/manifests/wanderer-empire.toml
+++ b/manifests/wanderer-empire.toml
@@ -25,7 +25,5 @@ regex = 'WandererEmpire-V(\d+\.\d+\.\d+)-Setup'
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{wandererempire}_is1"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Wanderer Astro\\ASCOM.WandererBox1.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Wanderer Astro\\ASCOM.WandererBox1.exe"

--- a/manifests/zwo-ascom-driver-pack.toml
+++ b/manifests/zwo-ascom-driver-pack.toml
@@ -30,7 +30,5 @@ requires = ["ascom-platform", "zwo-native-driver"]
 method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\ZWO ASCOM Driver_is1"
 registry_value = "DisplayVersion"
-
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\ZWO\\ASIMount\\AM5Install.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\ZWO\\ASIMount\\AM5Install.exe"


### PR DESCRIPTION
## Summary

- 31 manifests used `[detection.fallback]` nested TOML table syntax for fallback detection config
- The `Detection` struct in `crates/shared/src/manifest.rs` has flat fields (`fallback_method`, `fallback_path`), not a nested `fallback` struct
- Serde silently ignores the nested table, so fallback detection was never compiled into `catalog.db`
- Changed all 31 manifests to flat syntax matching the struct fields
- Also added `Astronomia` to typos allow-list (company name "Lunatico Astronomia")

## Affected files

31 manifest files across all vendors (APT, ASCOM, ASTAP, Celestron, Green Swamp, iOptron, Lunatico, MoonLite, Player One, PrimaLuce, QHY, Starlight Xpress, Wanderer, ZWO)

## Test plan

- [ ] Compile manifests: `cargo run -p astro-up-compiler -- --manifests manifests --output catalog.db`
- [ ] Verify fallback entries appear in catalog.db detection table
- [ ] On Windows, test detection fallback triggers when primary registry key is missing
