### PR TITLE
fix: correct category and type fields across 34 manifests

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -2,3 +2,8 @@
 # Windows API: Plug and Play
 PnP = "PnP"
 Pn = "Pn"
+# iOptron HAE series mount product name
+hae = "hae"
+HAE = "HAE"
+# Lunatico Astronomia company name
+Astronomia = "Astronomia"

--- a/manifests/apt-app.toml
+++ b/manifests/apt-app.toml
@@ -6,6 +6,7 @@ publisher = "APT"
 homepage = "https://astrophotography.app"
 category = "imaging"
 type = "application"
+tags = ["imaging", "capture", "sequencer", "apt"]
 slug = "apt-app"
 
 [install]

--- a/manifests/apt-app.toml
+++ b/manifests/apt-app.toml
@@ -4,7 +4,7 @@ name = "Astro Photography Tool"
 description = "Astro Photography Tool — DSO imaging and session automation"
 publisher = "APT"
 homepage = "https://astrophotography.app"
-category = "capture"
+category = "imaging"
 type = "application"
 slug = "apt-app"
 

--- a/manifests/ascom-platform.toml
+++ b/manifests/ascom-platform.toml
@@ -6,6 +6,7 @@ publisher = "ASCOM Initiative"
 homepage = "https://ascom-standards.org"
 category = "prerequisites"
 type = "runtime"
+tags = ["ascom", "driver-framework"]
 slug = "ascom-platform"
 
 [install]

--- a/manifests/ascom-remote-app.toml
+++ b/manifests/ascom-remote-app.toml
@@ -4,7 +4,7 @@ name = "ASCOM Remote Server"
 description = "ASCOM Remote Server — network access to ASCOM devices"
 publisher = "ASCOM Initiative"
 homepage = "https://ascom-standards.org"
-category = "utilities"
+category = "utility"
 type = "application"
 slug = "ascom-remote-app"
 

--- a/manifests/ascom-remote-app.toml
+++ b/manifests/ascom-remote-app.toml
@@ -6,6 +6,7 @@ publisher = "ASCOM Initiative"
 homepage = "https://ascom-standards.org"
 category = "utility"
 type = "application"
+tags = ["ascom", "remote", "alpaca"]
 slug = "ascom-remote-app"
 
 [install]

--- a/manifests/astap-app.toml
+++ b/manifests/astap-app.toml
@@ -6,6 +6,7 @@ publisher = "ASTAP"
 homepage = "https://www.hnsky.org/astap.htm"
 category = "platesolving"
 type = "application"
+tags = ["platesolving", "astrometry"]
 slug = "astap-app"
 
 [install]

--- a/manifests/astap-d20.toml
+++ b/manifests/astap-d20.toml
@@ -6,6 +6,7 @@ publisher = "ASTAP"
 homepage = "https://www.hnsky.org/astap.htm"
 category = "platesolving"
 type = "database"
+tags = ["database", "astap", "platesolving"]
 slug = "astap-d20"
 
 [detection]

--- a/manifests/astap-d50.toml
+++ b/manifests/astap-d50.toml
@@ -6,6 +6,7 @@ publisher = "ASTAP"
 homepage = "https://www.hnsky.org/astap.htm"
 category = "platesolving"
 type = "database"
+tags = ["database", "astap", "platesolving"]
 slug = "astap-d50"
 
 [detection]

--- a/manifests/astap-d80.toml
+++ b/manifests/astap-d80.toml
@@ -6,6 +6,7 @@ publisher = "ASTAP"
 homepage = "https://www.hnsky.org/astap.htm"
 category = "platesolving"
 type = "database"
+tags = ["database", "astap", "platesolving"]
 slug = "astap-d80"
 
 [install]

--- a/manifests/astap-g05.toml
+++ b/manifests/astap-g05.toml
@@ -6,6 +6,7 @@ publisher = "ASTAP"
 homepage = "https://www.hnsky.org/astap.htm"
 category = "platesolving"
 type = "database"
+tags = ["database", "astap", "platesolving"]
 slug = "astap-g05"
 
 [install]

--- a/manifests/astap-w08.toml
+++ b/manifests/astap-w08.toml
@@ -6,6 +6,7 @@ publisher = "ASTAP"
 homepage = "https://www.hnsky.org/astap.htm"
 category = "platesolving"
 type = "database"
+tags = ["database", "astap", "platesolving"]
 slug = "astap-w08"
 
 [install]

--- a/manifests/astroasis-focuser-ascom.toml
+++ b/manifests/astroasis-focuser-ascom.toml
@@ -6,6 +6,7 @@ publisher = "Astroasis"
 homepage = "https://www.astroasis.com"
 category = "driver"
 type = "driver"
+tags = ["ascom", "focuser", "astroasis"]
 slug = "astroasis-focuser-ascom"
 
 [install]

--- a/manifests/astroasis-focuser-firmware.toml
+++ b/manifests/astroasis-focuser-firmware.toml
@@ -6,6 +6,7 @@ publisher = "Astroasis"
 homepage = "https://www.astroasis.com"
 category = "driver"
 type = "firmware"
+tags = ["firmware", "focuser", "astroasis"]
 slug = "astroasis-focuser-firmware"
 
 [install]

--- a/manifests/astroasis-focuser-firmware.toml
+++ b/manifests/astroasis-focuser-firmware.toml
@@ -5,7 +5,7 @@ description = "Firmware update for Astroasis Oasis Focuser Rose"
 publisher = "Astroasis"
 homepage = "https://www.astroasis.com"
 category = "driver"
-type = "resource"
+type = "firmware"
 slug = "astroasis-focuser-firmware"
 
 [install]

--- a/manifests/astroasis-focuser-triple-ascom.toml
+++ b/manifests/astroasis-focuser-triple-ascom.toml
@@ -6,6 +6,7 @@ publisher = "Astroasis"
 homepage = "https://www.astroasis.com"
 category = "driver"
 type = "driver"
+tags = ["ascom", "focuser", "astroasis"]
 slug = "astroasis-focuser-triple-ascom"
 
 [install]

--- a/manifests/astroasis-fw-ascom.toml
+++ b/manifests/astroasis-fw-ascom.toml
@@ -6,6 +6,7 @@ publisher = "Astroasis"
 homepage = "https://www.astroasis.com"
 category = "driver"
 type = "driver"
+tags = ["ascom", "filterwheel", "astroasis"]
 slug = "astroasis-fw-ascom"
 
 [install]

--- a/manifests/astroasis-fw-firmware.toml
+++ b/manifests/astroasis-fw-firmware.toml
@@ -5,7 +5,7 @@ description = "Firmware update for Astroasis Oasis Filter Wheel"
 publisher = "Astroasis"
 homepage = "https://www.astroasis.com"
 category = "driver"
-type = "resource"
+type = "firmware"
 slug = "astroasis-fw-firmware"
 
 [install]

--- a/manifests/astroasis-fw-firmware.toml
+++ b/manifests/astroasis-fw-firmware.toml
@@ -6,6 +6,7 @@ publisher = "Astroasis"
 homepage = "https://www.astroasis.com"
 category = "driver"
 type = "firmware"
+tags = ["firmware", "filterwheel", "astroasis"]
 slug = "astroasis-fw-firmware"
 
 [install]

--- a/manifests/atik-core-software.toml
+++ b/manifests/atik-core-software.toml
@@ -6,6 +6,7 @@ publisher = "Atik Cameras"
 homepage = "https://www.atik-cameras.com"
 category = "driver"
 type = "driver"
+tags = ["camera", "atik"]
 slug = "atik-core-software"
 
 [install]

--- a/manifests/celestron-cfm.toml
+++ b/manifests/celestron-cfm.toml
@@ -6,6 +6,7 @@ publisher = "Celestron"
 homepage = "https://www.celestron.com"
 category = "driver"
 type = "application"
+tags = ["firmware", "celestron"]
 slug = "celestron-cfm"
 
 [install]

--- a/manifests/celestron-cpwi.toml
+++ b/manifests/celestron-cpwi.toml
@@ -6,6 +6,7 @@ publisher = "Celestron"
 homepage = "https://www.celestron.com"
 category = "driver"
 type = "application"
+tags = ["mount", "celestron"]
 slug = "celestron-cpwi"
 
 [install]

--- a/manifests/celestron-focuser-usb-ascom.toml
+++ b/manifests/celestron-focuser-usb-ascom.toml
@@ -6,6 +6,7 @@ publisher = "Celestron"
 homepage = "https://www.celestron.com"
 category = "driver"
 type = "driver"
+tags = ["ascom", "focuser", "celestron"]
 slug = "celestron-focuser-usb-ascom"
 
 [install]

--- a/manifests/cp210x-drivers.toml
+++ b/manifests/cp210x-drivers.toml
@@ -6,6 +6,7 @@ publisher = "Silicon Labs"
 homepage = "https://www.silabs.com"
 category = "driver"
 type = "driver"
+tags = ["usb", "serial"]
 slug = "cp210x-drivers"
 
 [detection]

--- a/manifests/cp210x-drivers.toml
+++ b/manifests/cp210x-drivers.toml
@@ -4,8 +4,8 @@ name = "Silicon Labs CP210x Drivers"
 description = "Silicon Labs CP210x USB to UART bridge VCP drivers"
 publisher = "Silicon Labs"
 homepage = "https://www.silabs.com"
-category = "usb"
-type = "usb_driver"
+category = "driver"
+type = "driver"
 slug = "cp210x-drivers"
 
 [detection]

--- a/manifests/dotnet-desktop-8.toml
+++ b/manifests/dotnet-desktop-8.toml
@@ -6,6 +6,7 @@ publisher = "Microsoft"
 homepage = "https://dotnet.microsoft.com"
 category = "prerequisites"
 type = "runtime"
+tags = ["dotnet", "runtime", "microsoft"]
 slug = "dotnet-desktop-8"
 
 [detection]

--- a/manifests/dotnet-desktop-8.toml
+++ b/manifests/dotnet-desktop-8.toml
@@ -23,7 +23,7 @@ silent = "/install /quiet /norestart"
 [checkver]
 provider = "browser_scrape"
 url = "https://dotnet.microsoft.com/en-us/download/dotnet/8.0"
-regex = '\.NET 8.*?(\d+\.\d+\.\d+)'
+regex = '\.NET Desktop Runtime (\d+\.\d+\.\d+)'
 
 [checkver.autoupdate]
 url = "https://aka.ms/dotnet/8.0/windowsdesktop-runtime-win-x64.exe"

--- a/manifests/eqmod-app.toml
+++ b/manifests/eqmod-app.toml
@@ -4,7 +4,7 @@ name = "EQMOD"
 description = "EQMOD — ASCOM driver for Synta/SkyWatcher EQ mounts"
 publisher = "EQMOD Project"
 homepage = "https://eq-mod.sourceforge.net"
-category = "utilities"
+category = "utility"
 type = "application"
 slug = "eqmod-app"
 

--- a/manifests/eqmod-app.toml
+++ b/manifests/eqmod-app.toml
@@ -6,6 +6,7 @@ publisher = "EQMOD Project"
 homepage = "https://eq-mod.sourceforge.net"
 category = "utility"
 type = "application"
+tags = ["ascom", "mount", "eqmod"]
 slug = "eqmod-app"
 
 [install]

--- a/manifests/firecapture-app.toml
+++ b/manifests/firecapture-app.toml
@@ -5,7 +5,7 @@ name = "FireCapture"
 description = "FireCapture — planetary imaging capture"
 publisher = "FireCapture"
 homepage = "https://www.firecapture.de"
-category = "capture"
+category = "imaging"
 type = "application"
 slug = "firecapture-app"
 

--- a/manifests/firecapture-app.toml
+++ b/manifests/firecapture-app.toml
@@ -7,6 +7,7 @@ publisher = "FireCapture"
 homepage = "https://www.firecapture.de"
 category = "imaging"
 type = "application"
+tags = ["imaging", "capture", "planetary"]
 slug = "firecapture-app"
 
 [detection]

--- a/manifests/green-swamp-server-app.toml
+++ b/manifests/green-swamp-server-app.toml
@@ -6,6 +6,7 @@ publisher = "Green Swamp Server"
 homepage = "https://greenswamp.org"
 category = "utility"
 type = "application"
+tags = ["mount", "ascom", "gss"]
 slug = "green-swamp-server-app"
 
 [install]

--- a/manifests/green-swamp-server-app.toml
+++ b/manifests/green-swamp-server-app.toml
@@ -4,7 +4,7 @@ name = "Green Swamp Server"
 description = "Green Swamp Server (GSServer) — ASCOM telescope driver for SkyWatcher/Orion mounts"
 publisher = "Green Swamp Server"
 homepage = "https://greenswamp.org"
-category = "utilities"
+category = "utility"
 type = "application"
 slug = "green-swamp-server-app"
 

--- a/manifests/ioptron-cem120-firmware.toml
+++ b/manifests/ioptron-cem120-firmware.toml
@@ -6,6 +6,7 @@ publisher = "iOptron"
 homepage = "https://www.ioptron.com"
 category = "driver"
 type = "firmware"
+tags = ["firmware", "mount", "ioptron"]
 slug = "ioptron-cem120-firmware"
 
 [install]

--- a/manifests/ioptron-cem120-firmware.toml
+++ b/manifests/ioptron-cem120-firmware.toml
@@ -5,7 +5,7 @@ description = "Firmware for iOptron CEM120 mount"
 publisher = "iOptron"
 homepage = "https://www.ioptron.com"
 category = "driver"
-type = "resource"
+type = "firmware"
 slug = "ioptron-cem120-firmware"
 
 [install]

--- a/manifests/ioptron-cem26-firmware.toml
+++ b/manifests/ioptron-cem26-firmware.toml
@@ -5,7 +5,7 @@ description = "Firmware for iOptron CEM26 and GEM28 mounts"
 publisher = "iOptron"
 homepage = "https://www.ioptron.com"
 category = "driver"
-type = "resource"
+type = "firmware"
 slug = "ioptron-cem26-firmware"
 
 [install]

--- a/manifests/ioptron-cem26-firmware.toml
+++ b/manifests/ioptron-cem26-firmware.toml
@@ -6,6 +6,7 @@ publisher = "iOptron"
 homepage = "https://www.ioptron.com"
 category = "driver"
 type = "firmware"
+tags = ["firmware", "mount", "ioptron"]
 slug = "ioptron-cem26-firmware"
 
 [install]

--- a/manifests/ioptron-cem40-firmware.toml
+++ b/manifests/ioptron-cem40-firmware.toml
@@ -6,6 +6,7 @@ publisher = "iOptron"
 homepage = "https://www.ioptron.com"
 category = "driver"
 type = "firmware"
+tags = ["firmware", "mount", "ioptron"]
 slug = "ioptron-cem40-firmware"
 
 [install]

--- a/manifests/ioptron-cem40-firmware.toml
+++ b/manifests/ioptron-cem40-firmware.toml
@@ -5,7 +5,7 @@ description = "Firmware for iOptron CEM40 and GEM45 mounts"
 publisher = "iOptron"
 homepage = "https://www.ioptron.com"
 category = "driver"
-type = "resource"
+type = "firmware"
 slug = "ioptron-cem40-firmware"
 
 [install]

--- a/manifests/ioptron-cem70-firmware.toml
+++ b/manifests/ioptron-cem70-firmware.toml
@@ -5,7 +5,7 @@ description = "Firmware for iOptron CEM70 mount"
 publisher = "iOptron"
 homepage = "https://www.ioptron.com"
 category = "driver"
-type = "resource"
+type = "firmware"
 slug = "ioptron-cem70-firmware"
 
 [install]

--- a/manifests/ioptron-cem70-firmware.toml
+++ b/manifests/ioptron-cem70-firmware.toml
@@ -6,6 +6,7 @@ publisher = "iOptron"
 homepage = "https://www.ioptron.com"
 category = "driver"
 type = "firmware"
+tags = ["firmware", "mount", "ioptron"]
 slug = "ioptron-cem70-firmware"
 
 [install]

--- a/manifests/ioptron-commander-ascom.toml
+++ b/manifests/ioptron-commander-ascom.toml
@@ -6,6 +6,7 @@ publisher = "iOptron"
 homepage = "https://www.ioptron.com"
 category = "driver"
 type = "application"
+tags = ["ascom", "mount", "ioptron"]
 slug = "ioptron-commander-ascom"
 
 [install]

--- a/manifests/ioptron-hae-bc-firmware.toml
+++ b/manifests/ioptron-hae-bc-firmware.toml
@@ -6,6 +6,7 @@ publisher = "iOptron"
 homepage = "https://www.ioptron.com"
 category = "driver"
 type = "firmware"
+tags = ["firmware", "mount", "ioptron"]
 slug = "ioptron-hae-bc-firmware"
 
 [install]

--- a/manifests/ioptron-hae-bc-firmware.toml
+++ b/manifests/ioptron-hae-bc-firmware.toml
@@ -5,7 +5,7 @@ description = "Firmware for iOptron HAE-BC mount"
 publisher = "iOptron"
 homepage = "https://www.ioptron.com"
 category = "driver"
-type = "resource"
+type = "firmware"
 slug = "ioptron-hae-bc-firmware"
 
 [install]

--- a/manifests/ioptron-hae-firmware.toml
+++ b/manifests/ioptron-hae-firmware.toml
@@ -6,6 +6,7 @@ publisher = "iOptron"
 homepage = "https://www.ioptron.com"
 category = "driver"
 type = "firmware"
+tags = ["firmware", "mount", "ioptron"]
 slug = "ioptron-hae-firmware"
 
 [install]

--- a/manifests/ioptron-hae-firmware.toml
+++ b/manifests/ioptron-hae-firmware.toml
@@ -5,7 +5,7 @@ description = "Firmware for iOptron HAE series AZ/EQ hybrid strain wave gear mou
 publisher = "iOptron"
 homepage = "https://www.ioptron.com"
 category = "driver"
-type = "resource"
+type = "firmware"
 slug = "ioptron-hae-firmware"
 
 [install]

--- a/manifests/ioptron-haz-firmware.toml
+++ b/manifests/ioptron-haz-firmware.toml
@@ -6,6 +6,7 @@ publisher = "iOptron"
 homepage = "https://www.ioptron.com"
 category = "driver"
 type = "firmware"
+tags = ["firmware", "mount", "ioptron"]
 slug = "ioptron-haz-firmware"
 
 [install]

--- a/manifests/ioptron-haz-firmware.toml
+++ b/manifests/ioptron-haz-firmware.toml
@@ -5,7 +5,7 @@ description = "Firmware for iOptron HAZ series altazimuth strain wave gear mount
 publisher = "iOptron"
 homepage = "https://www.ioptron.com"
 category = "driver"
-type = "resource"
+type = "firmware"
 slug = "ioptron-haz-firmware"
 
 [install]

--- a/manifests/ioptron-hem-firmware.toml
+++ b/manifests/ioptron-hem-firmware.toml
@@ -5,7 +5,7 @@ description = "Firmware for iOptron HEM series harmonic equatorial mounts"
 publisher = "iOptron"
 homepage = "https://www.ioptron.com"
 category = "driver"
-type = "resource"
+type = "firmware"
 slug = "ioptron-hem-firmware"
 
 [install]

--- a/manifests/ioptron-hem-firmware.toml
+++ b/manifests/ioptron-hem-firmware.toml
@@ -6,6 +6,7 @@ publisher = "iOptron"
 homepage = "https://www.ioptron.com"
 category = "driver"
 type = "firmware"
+tags = ["firmware", "mount", "ioptron"]
 slug = "ioptron-hem-firmware"
 
 [install]

--- a/manifests/ioptron-ipolar.toml
+++ b/manifests/ioptron-ipolar.toml
@@ -6,6 +6,7 @@ publisher = "iOptron"
 homepage = "https://www.ioptron.com"
 category = "driver"
 type = "application"
+tags = ["polar-alignment", "ioptron"]
 slug = "ioptron-ipolar"
 
 [install]

--- a/manifests/ioptron-upgrade-utility-v2.toml
+++ b/manifests/ioptron-upgrade-utility-v2.toml
@@ -6,6 +6,7 @@ publisher = "iOptron"
 homepage = "https://www.ioptron.com"
 category = "driver"
 type = "application"
+tags = ["firmware", "mount", "ioptron"]
 slug = "ioptron-upgrade-utility-v2"
 
 [detection]

--- a/manifests/ioptron-upgrade-utility-v3-21.toml
+++ b/manifests/ioptron-upgrade-utility-v3-21.toml
@@ -6,6 +6,7 @@ publisher = "iOptron"
 homepage = "https://www.ioptron.com"
 category = "driver"
 type = "application"
+tags = ["firmware", "mount", "ioptron"]
 slug = "ioptron-upgrade-utility-v3-21"
 
 [install]

--- a/manifests/ioptron-upgrade-utility-v3.toml
+++ b/manifests/ioptron-upgrade-utility-v3.toml
@@ -6,6 +6,7 @@ publisher = "iOptron"
 homepage = "https://www.ioptron.com"
 category = "driver"
 type = "application"
+tags = ["firmware", "mount", "ioptron"]
 slug = "ioptron-upgrade-utility-v3"
 
 [detection]

--- a/manifests/losmandy-gemini-firmware.toml
+++ b/manifests/losmandy-gemini-firmware.toml
@@ -5,7 +5,7 @@ description = "Firmware for Losmandy Gemini 2 telescope mount controller"
 publisher = "Losmandy"
 homepage = "https://gemini-2.com"
 category = "driver"
-type = "resource"
+type = "firmware"
 slug = "losmandy-gemini-firmware"
 
 [install]

--- a/manifests/losmandy-gemini-firmware.toml
+++ b/manifests/losmandy-gemini-firmware.toml
@@ -6,6 +6,7 @@ publisher = "Losmandy"
 homepage = "https://gemini-2.com"
 category = "driver"
 type = "firmware"
+tags = ["firmware", "mount", "losmandy"]
 slug = "losmandy-gemini-firmware"
 
 [install]

--- a/manifests/lunatico-cloudwatcher-ascom.toml
+++ b/manifests/lunatico-cloudwatcher-ascom.toml
@@ -6,6 +6,7 @@ publisher = "Lunatico Astronomia"
 homepage = "https://lunaticoastro.com"
 category = "driver"
 type = "driver"
+tags = ["ascom", "weather", "lunatico"]
 slug = "lunatico-cloudwatcher-ascom"
 
 [install]

--- a/manifests/lunatico-cloudwatcher-firmware.toml
+++ b/manifests/lunatico-cloudwatcher-firmware.toml
@@ -5,7 +5,7 @@ description = "Firmware for Lunatico AAG CloudWatcher"
 publisher = "Lunatico Astronomia"
 homepage = "https://lunaticoastro.com"
 category = "driver"
-type = "resource"
+type = "firmware"
 slug = "lunatico-cloudwatcher-firmware"
 
 [install]

--- a/manifests/lunatico-cloudwatcher-firmware.toml
+++ b/manifests/lunatico-cloudwatcher-firmware.toml
@@ -6,6 +6,7 @@ publisher = "Lunatico Astronomia"
 homepage = "https://lunaticoastro.com"
 category = "driver"
 type = "firmware"
+tags = ["firmware", "weather", "lunatico"]
 slug = "lunatico-cloudwatcher-firmware"
 
 [install]

--- a/manifests/lunatico-cloudwatcher-software.toml
+++ b/manifests/lunatico-cloudwatcher-software.toml
@@ -6,6 +6,7 @@ publisher = "Lunatico Astronomia"
 homepage = "https://lunaticoastro.com"
 category = "driver"
 type = "application"
+tags = ["weather", "lunatico"]
 slug = "lunatico-cloudwatcher-software"
 
 [install]

--- a/manifests/lunatico-dragonfly.toml
+++ b/manifests/lunatico-dragonfly.toml
@@ -6,6 +6,7 @@ publisher = "Lunatico Astronomia"
 homepage = "https://lunaticoastro.com"
 category = "driver"
 type = "driver"
+tags = ["ascom", "focuser", "rotator", "lunatico"]
 slug = "lunatico-dragonfly"
 
 [install]

--- a/manifests/moonlite-dro-ascom.toml
+++ b/manifests/moonlite-dro-ascom.toml
@@ -6,6 +6,7 @@ publisher = "MoonLite"
 homepage = "https://focuser.com"
 category = "driver"
 type = "driver"
+tags = ["ascom", "focuser", "moonlite"]
 slug = "moonlite-dro-ascom"
 
 [install]

--- a/manifests/moonlite-nitecrawler-ascom.toml
+++ b/manifests/moonlite-nitecrawler-ascom.toml
@@ -6,6 +6,7 @@ publisher = "MoonLite"
 homepage = "https://focuser.com"
 category = "driver"
 type = "driver"
+tags = ["ascom", "focuser", "moonlite"]
 slug = "moonlite-nitecrawler-ascom"
 
 [install]

--- a/manifests/moonlite-nitecrawler-control.toml
+++ b/manifests/moonlite-nitecrawler-control.toml
@@ -6,6 +6,7 @@ publisher = "MoonLite"
 homepage = "https://focuser.com"
 category = "driver"
 type = "application"
+tags = ["focuser", "moonlite"]
 slug = "moonlite-nitecrawler-control"
 
 [detection]

--- a/manifests/moonlite-single-focuser.toml
+++ b/manifests/moonlite-single-focuser.toml
@@ -6,6 +6,7 @@ publisher = "MoonLite"
 homepage = "https://focuser.com"
 category = "driver"
 type = "application"
+tags = ["focuser", "moonlite"]
 slug = "moonlite-single-focuser"
 
 [detection]

--- a/manifests/nexdome-ascom.toml
+++ b/manifests/nexdome-ascom.toml
@@ -6,6 +6,7 @@ publisher = "NexDome"
 homepage = "https://nexdome.com"
 category = "driver"
 type = "driver"
+tags = ["ascom", "observatory", "dome", "nexdome"]
 slug = "nexdome-ascom"
 
 [install]

--- a/manifests/nina-app.toml
+++ b/manifests/nina-app.toml
@@ -4,10 +4,10 @@ name = "N.I.N.A."
 description = "Nighttime Imaging 'N' Astronomy — astrophotography imaging suite"
 publisher = "NINA Contributors"
 homepage = "https://nighttime-imaging.eu"
-category = "capture"
+category = "imaging"
 type = "application"
 slug = "nina-app"
-tags = ["imaging", "capture", "sequencer", "phd2", "platesolving"]
+tags = ["imaging", "capture", "sequencer", "automation"]
 aliases = ["nina"]
 license = "MPL-2.0"
 

--- a/manifests/nina-framing-cache-full.toml
+++ b/manifests/nina-framing-cache-full.toml
@@ -4,7 +4,7 @@ name = "NINA Framing Assistant Cache (Full Sky)"
 description = "Complete offline sky map cache for NINA Framing Assistant (3.3 GB, DSS/STScI survey)"
 publisher = "NINA Contributors"
 homepage = "https://nighttime-imaging.eu"
-category = "capture"
+category = "imaging"
 type = "database"
 slug = "nina-framing-cache-full"
 

--- a/manifests/nina-framing-cache-full.toml
+++ b/manifests/nina-framing-cache-full.toml
@@ -6,6 +6,7 @@ publisher = "NINA Contributors"
 homepage = "https://nighttime-imaging.eu"
 category = "imaging"
 type = "database"
+tags = ["database", "nina", "framing"]
 slug = "nina-framing-cache-full"
 
 [detection]

--- a/manifests/nina-framing-cache-northern-starless.toml
+++ b/manifests/nina-framing-cache-northern-starless.toml
@@ -4,7 +4,7 @@ name = "NINA Framing Assistant Cache (Northern Sky, Starless)"
 description = "Northern sky narrowband starless offline cache for NINA Framing Assistant (471 MB)"
 publisher = "NINA Contributors"
 homepage = "https://nighttime-imaging.eu"
-category = "capture"
+category = "imaging"
 type = "database"
 slug = "nina-framing-cache-northern-starless"
 

--- a/manifests/nina-framing-cache-northern-starless.toml
+++ b/manifests/nina-framing-cache-northern-starless.toml
@@ -6,6 +6,7 @@ publisher = "NINA Contributors"
 homepage = "https://nighttime-imaging.eu"
 category = "imaging"
 type = "database"
+tags = ["database", "nina", "framing"]
 slug = "nina-framing-cache-northern-starless"
 
 [detection]

--- a/manifests/nina-framing-cache-northern.toml
+++ b/manifests/nina-framing-cache-northern.toml
@@ -4,7 +4,7 @@ name = "NINA Framing Assistant Cache (Northern Sky)"
 description = "Northern sky narrowband offline cache for NINA Framing Assistant (1.4 GB, down to -17 Dec)"
 publisher = "NINA Contributors"
 homepage = "https://nighttime-imaging.eu"
-category = "capture"
+category = "imaging"
 type = "database"
 slug = "nina-framing-cache-northern"
 

--- a/manifests/nina-framing-cache-northern.toml
+++ b/manifests/nina-framing-cache-northern.toml
@@ -6,6 +6,7 @@ publisher = "NINA Contributors"
 homepage = "https://nighttime-imaging.eu"
 category = "imaging"
 type = "database"
+tags = ["database", "nina", "framing"]
 slug = "nina-framing-cache-northern"
 
 [detection]

--- a/manifests/pegasus-unity-platform.toml
+++ b/manifests/pegasus-unity-platform.toml
@@ -6,6 +6,7 @@ publisher = "Pegasus Astro"
 homepage = "https://pegasusastro.com"
 category = "driver"
 type = "application"
+tags = ["power", "focuser", "pegasus"]
 slug = "pegasus-unity-platform"
 aliases = ["Unity3 Platform"]
 

--- a/manifests/phd2-app.toml
+++ b/manifests/phd2-app.toml
@@ -6,6 +6,7 @@ publisher = "OpenPHD"
 homepage = "https://openphdguiding.org"
 category = "guiding"
 type = "application"
+tags = ["guiding", "autoguider", "phd2"]
 slug = "phd2-app"
 
 [install]

--- a/manifests/player-one-camera-ascom.toml
+++ b/manifests/player-one-camera-ascom.toml
@@ -6,6 +6,7 @@ publisher = "Player One Astronomy"
 homepage = "https://player-one-astronomy.com"
 category = "driver"
 type = "driver"
+tags = ["ascom", "camera", "playerone"]
 slug = "player-one-camera-ascom"
 
 [install]

--- a/manifests/player-one-directshow.toml
+++ b/manifests/player-one-directshow.toml
@@ -6,6 +6,7 @@ publisher = "Player One Astronomy"
 homepage = "https://player-one-astronomy.com"
 category = "driver"
 type = "driver"
+tags = ["camera", "playerone"]
 slug = "player-one-directshow"
 
 [install]

--- a/manifests/player-one-fw-ascom.toml
+++ b/manifests/player-one-fw-ascom.toml
@@ -6,6 +6,7 @@ publisher = "Player One Astronomy"
 homepage = "https://player-one-astronomy.com"
 category = "driver"
 type = "driver"
+tags = ["ascom", "filterwheel", "playerone"]
 slug = "player-one-fw-ascom"
 
 [install]

--- a/manifests/player-one-native-driver.toml
+++ b/manifests/player-one-native-driver.toml
@@ -5,7 +5,7 @@ description = "Native USB driver for Player One astronomy cameras"
 publisher = "Player One Astronomy"
 homepage = "https://player-one-astronomy.com"
 category = "driver"
-type = "usb_driver"
+type = "driver"
 slug = "player-one-native-driver"
 
 [detection]

--- a/manifests/player-one-native-driver.toml
+++ b/manifests/player-one-native-driver.toml
@@ -6,6 +6,7 @@ publisher = "Player One Astronomy"
 homepage = "https://player-one-astronomy.com"
 category = "driver"
 type = "driver"
+tags = ["camera", "playerone"]
 slug = "player-one-native-driver"
 
 [detection]

--- a/manifests/primaluce-alto.toml
+++ b/manifests/primaluce-alto.toml
@@ -6,6 +6,7 @@ publisher = "PrimaLuce Lab"
 homepage = "https://www.primalucelab.com"
 category = "driver"
 type = "driver"
+tags = ["ascom", "focuser", "primaluce"]
 slug = "primaluce-alto"
 
 [install]

--- a/manifests/primaluce-arco.toml
+++ b/manifests/primaluce-arco.toml
@@ -6,6 +6,7 @@ publisher = "PrimaLuce Lab"
 homepage = "https://www.primalucelab.com"
 category = "driver"
 type = "driver"
+tags = ["ascom", "rotator", "primaluce"]
 slug = "primaluce-arco"
 
 [install]

--- a/manifests/primaluce-eagle-x.toml
+++ b/manifests/primaluce-eagle-x.toml
@@ -6,6 +6,7 @@ publisher = "PrimaLuce Lab"
 homepage = "https://www.primalucelab.com"
 category = "utility"
 type = "application"
+tags = ["observatory", "primaluce"]
 slug = "primaluce-eagle-x"
 
 [install]

--- a/manifests/primaluce-eagle-x.toml
+++ b/manifests/primaluce-eagle-x.toml
@@ -4,7 +4,7 @@ name = "PrimaLuce EAGLE X Software Package"
 description = "Software package for PrimaLuce EAGLE X telescope computer"
 publisher = "PrimaLuce Lab"
 homepage = "https://www.primalucelab.com"
-category = "utilities"
+category = "utility"
 type = "application"
 slug = "primaluce-eagle-x"
 

--- a/manifests/primaluce-ecco2.toml
+++ b/manifests/primaluce-ecco2.toml
@@ -6,6 +6,7 @@ publisher = "PrimaLuce Lab"
 homepage = "https://www.primalucelab.com"
 category = "driver"
 type = "driver"
+tags = ["ascom", "dew-heater", "primaluce"]
 slug = "primaluce-ecco2"
 
 [install]

--- a/manifests/primaluce-esatto.toml
+++ b/manifests/primaluce-esatto.toml
@@ -6,6 +6,7 @@ publisher = "PrimaLuce Lab"
 homepage = "https://www.primalucelab.com"
 category = "driver"
 type = "driver"
+tags = ["ascom", "focuser", "primaluce"]
 slug = "primaluce-esatto"
 
 [install]

--- a/manifests/primaluce-giotto.toml
+++ b/manifests/primaluce-giotto.toml
@@ -6,6 +6,7 @@ publisher = "PrimaLuce Lab"
 homepage = "https://www.primalucelab.com"
 category = "driver"
 type = "driver"
+tags = ["ascom", "flatpanel", "primaluce"]
 slug = "primaluce-giotto"
 
 [install]

--- a/manifests/primaluce-play.toml
+++ b/manifests/primaluce-play.toml
@@ -4,7 +4,7 @@ name = "PrimaLuce PLAY"
 description = "PrimaLuce Lab all-in-one control software for imaging and device management"
 publisher = "PrimaLuce Lab"
 homepage = "https://www.primalucelab.com"
-category = "capture"
+category = "imaging"
 type = "application"
 slug = "primaluce-play"
 

--- a/manifests/primaluce-play.toml
+++ b/manifests/primaluce-play.toml
@@ -6,6 +6,7 @@ publisher = "PrimaLuce Lab"
 homepage = "https://www.primalucelab.com"
 category = "imaging"
 type = "application"
+tags = ["imaging", "capture", "primaluce"]
 slug = "primaluce-play"
 
 [install]

--- a/manifests/primaluce-sesto-senso-2.toml
+++ b/manifests/primaluce-sesto-senso-2.toml
@@ -6,6 +6,7 @@ publisher = "PrimaLuce Lab"
 homepage = "https://www.primalucelab.com"
 category = "driver"
 type = "driver"
+tags = ["ascom", "focuser", "primaluce"]
 slug = "primaluce-sesto-senso-2"
 
 [install]

--- a/manifests/primaluce-sesto-senso-3.toml
+++ b/manifests/primaluce-sesto-senso-3.toml
@@ -6,6 +6,7 @@ publisher = "PrimaLuce Lab"
 homepage = "https://www.primalucelab.com"
 category = "driver"
 type = "driver"
+tags = ["ascom", "focuser", "primaluce"]
 slug = "primaluce-sesto-senso-3"
 
 [install]

--- a/manifests/prolific-drivers.toml
+++ b/manifests/prolific-drivers.toml
@@ -7,6 +7,7 @@ publisher = "Prolific"
 homepage = "https://www.prolific.com.tw"
 category = "driver"
 type = "driver"
+tags = ["usb", "serial"]
 slug = "prolific-drivers"
 
 [detection]

--- a/manifests/prolific-drivers.toml
+++ b/manifests/prolific-drivers.toml
@@ -5,8 +5,8 @@ name = "Prolific PL2303 Drivers"
 description = "Prolific PL2303 USB-serial drivers — used by many astronomy mount cables"
 publisher = "Prolific"
 homepage = "https://www.prolific.com.tw"
-category = "usb"
-type = "usb_driver"
+category = "driver"
+type = "driver"
 slug = "prolific-drivers"
 
 [detection]

--- a/manifests/qhy-allinone-beta.toml
+++ b/manifests/qhy-allinone-beta.toml
@@ -6,6 +6,7 @@ publisher = "QHY"
 homepage = "https://www.qhyccd.com"
 category = "driver"
 type = "driver"
+tags = ["camera", "filterwheel", "qhy"]
 slug = "qhy-allinone-beta"
 
 [install]

--- a/manifests/qhy-allinone.toml
+++ b/manifests/qhy-allinone.toml
@@ -6,6 +6,7 @@ publisher = "QHY"
 homepage = "https://www.qhyccd.com"
 category = "driver"
 type = "driver"
+tags = ["camera", "filterwheel", "qhy"]
 slug = "qhy-allinone"
 
 [install]

--- a/manifests/qhy-polemaster.toml
+++ b/manifests/qhy-polemaster.toml
@@ -6,6 +6,7 @@ publisher = "QHY"
 homepage = "https://www.qhyccd.com"
 category = "utility"
 type = "application"
+tags = ["polar-alignment", "qhy"]
 slug = "qhy-polemaster"
 
 [install]

--- a/manifests/qhy-polemaster.toml
+++ b/manifests/qhy-polemaster.toml
@@ -4,7 +4,7 @@ name = "QHY PoleMaster"
 description = "QHY PoleMaster electronic polar alignment software"
 publisher = "QHY"
 homepage = "https://www.qhyccd.com"
-category = "utilities"
+category = "utility"
 type = "application"
 slug = "qhy-polemaster"
 

--- a/manifests/qhy-qfocuser.toml
+++ b/manifests/qhy-qfocuser.toml
@@ -6,6 +6,7 @@ publisher = "QHY"
 homepage = "https://www.qhyccd.com"
 category = "driver"
 type = "driver"
+tags = ["ascom", "focuser", "qhy"]
 slug = "qhy-qfocuser"
 
 [install]

--- a/manifests/sharpcap-app.toml
+++ b/manifests/sharpcap-app.toml
@@ -4,7 +4,7 @@ name = "SharpCap"
 description = "SharpCap — live stacking and planetary/DSO capture"
 publisher = "SharpCap"
 homepage = "https://www.sharpcap.co.uk"
-category = "capture"
+category = "imaging"
 type = "application"
 slug = "sharpcap-app"
 

--- a/manifests/sharpcap-app.toml
+++ b/manifests/sharpcap-app.toml
@@ -6,6 +6,7 @@ publisher = "SharpCap"
 homepage = "https://www.sharpcap.co.uk"
 category = "imaging"
 type = "application"
+tags = ["imaging", "capture", "sharpcap"]
 slug = "sharpcap-app"
 
 [install]

--- a/manifests/stellarium-app.toml
+++ b/manifests/stellarium-app.toml
@@ -6,6 +6,7 @@ publisher = "Stellarium"
 homepage = "https://stellarium.org"
 category = "planetarium"
 type = "application"
+tags = ["planetarium", "star-chart"]
 slug = "stellarium-app"
 
 [install]

--- a/manifests/sx-camera-ascom.toml
+++ b/manifests/sx-camera-ascom.toml
@@ -6,6 +6,7 @@ publisher = "Starlight Xpress"
 homepage = "https://www.sxccd.com"
 category = "driver"
 type = "driver"
+tags = ["ascom", "camera", "starlight-xpress"]
 slug = "sx-camera-ascom"
 
 [install]

--- a/manifests/sx-fw-ascom.toml
+++ b/manifests/sx-fw-ascom.toml
@@ -6,6 +6,7 @@ publisher = "Starlight Xpress"
 homepage = "https://www.sxccd.com"
 category = "driver"
 type = "driver"
+tags = ["ascom", "filterwheel", "starlight-xpress"]
 slug = "sx-fw-ascom"
 
 [install]

--- a/manifests/sx-native-driver.toml
+++ b/manifests/sx-native-driver.toml
@@ -6,6 +6,7 @@ publisher = "Starlight Xpress"
 homepage = "https://www.sxccd.com"
 category = "driver"
 type = "driver"
+tags = ["camera", "starlight-xpress"]
 slug = "sx-native-driver"
 
 [detection]

--- a/manifests/sx-native-driver.toml
+++ b/manifests/sx-native-driver.toml
@@ -5,7 +5,7 @@ description = "Native USB driver for Starlight Xpress CCD cameras"
 publisher = "Starlight Xpress"
 homepage = "https://www.sxccd.com"
 category = "driver"
-type = "usb_driver"
+type = "driver"
 slug = "sx-native-driver"
 
 [detection]

--- a/manifests/synscan-app-ascom.toml
+++ b/manifests/synscan-app-ascom.toml
@@ -6,6 +6,7 @@ publisher = "Sky-Watcher"
 homepage = "https://www.skywatcher.com"
 category = "driver"
 type = "driver"
+tags = ["ascom", "mount", "skywatcher"]
 slug = "synscan-app-ascom"
 
 [install]

--- a/manifests/synscan-firmware-loader-wifi.toml
+++ b/manifests/synscan-firmware-loader-wifi.toml
@@ -6,6 +6,7 @@ publisher = "Sky-Watcher"
 homepage = "https://www.skywatcher.com"
 category = "driver"
 type = "application"
+tags = ["firmware", "mount", "skywatcher"]
 slug = "synscan-firmware-loader-wifi"
 
 [detection]

--- a/manifests/synscan-firmware-loader.toml
+++ b/manifests/synscan-firmware-loader.toml
@@ -6,6 +6,7 @@ publisher = "Sky-Watcher"
 homepage = "https://www.skywatcher.com"
 category = "driver"
 type = "application"
+tags = ["firmware", "mount", "skywatcher"]
 slug = "synscan-firmware-loader"
 
 [detection]

--- a/manifests/synscan-hc-firmware.toml
+++ b/manifests/synscan-hc-firmware.toml
@@ -6,7 +6,7 @@ description = "Firmware for SynScan hand controller"
 publisher = "Sky-Watcher"
 homepage = "https://www.skywatcher.com"
 category = "driver"
-type = "resource"
+type = "firmware"
 slug = "synscan-hc-firmware"
 
 [install]

--- a/manifests/synscan-hc-firmware.toml
+++ b/manifests/synscan-hc-firmware.toml
@@ -7,6 +7,7 @@ publisher = "Sky-Watcher"
 homepage = "https://www.skywatcher.com"
 category = "driver"
 type = "firmware"
+tags = ["firmware", "mount", "skywatcher"]
 slug = "synscan-hc-firmware"
 
 [install]

--- a/manifests/synscan-mc014-firmware.toml
+++ b/manifests/synscan-mc014-firmware.toml
@@ -6,7 +6,7 @@ description = "DC motor firmware for AZ-GTi/AZ-GTe/AZ-GTiX/Virtuoso GTi/Skyliner
 publisher = "Sky-Watcher"
 homepage = "https://www.skywatcher.com"
 category = "driver"
-type = "resource"
+type = "firmware"
 slug = "synscan-mc014-firmware"
 
 [install]

--- a/manifests/synscan-mc014-firmware.toml
+++ b/manifests/synscan-mc014-firmware.toml
@@ -7,6 +7,7 @@ publisher = "Sky-Watcher"
 homepage = "https://www.skywatcher.com"
 category = "driver"
 type = "firmware"
+tags = ["firmware", "mount", "skywatcher"]
 slug = "synscan-mc014-firmware"
 
 [install]

--- a/manifests/synscan-mc015-firmware.toml
+++ b/manifests/synscan-mc015-firmware.toml
@@ -6,7 +6,7 @@ description = "Stepper motor firmware for EQ6/EQ6-R/AZ-EQ6/EQ8/EQ8-R/EQ8-RH/CQ35
 publisher = "Sky-Watcher"
 homepage = "https://www.skywatcher.com"
 category = "driver"
-type = "resource"
+type = "firmware"
 slug = "synscan-mc015-firmware"
 
 [install]

--- a/manifests/synscan-mc015-firmware.toml
+++ b/manifests/synscan-mc015-firmware.toml
@@ -7,6 +7,7 @@ publisher = "Sky-Watcher"
 homepage = "https://www.skywatcher.com"
 category = "driver"
 type = "firmware"
+tags = ["firmware", "mount", "skywatcher"]
 slug = "synscan-mc015-firmware"
 
 [install]

--- a/manifests/synscan-mc016-firmware.toml
+++ b/manifests/synscan-mc016-firmware.toml
@@ -6,6 +6,7 @@ publisher = "Sky-Watcher"
 homepage = "https://www.skywatcher.com"
 category = "driver"
 type = "firmware"
+tags = ["firmware", "mount", "skywatcher"]
 slug = "synscan-mc016-firmware"
 
 [install]

--- a/manifests/synscan-mc016-firmware.toml
+++ b/manifests/synscan-mc016-firmware.toml
@@ -5,7 +5,7 @@ description = "EQ-AL55i Pro firmware"
 publisher = "Sky-Watcher"
 homepage = "https://www.skywatcher.com"
 category = "driver"
-type = "resource"
+type = "firmware"
 slug = "synscan-mc016-firmware"
 
 [install]

--- a/manifests/synscan-mc019-firmware.toml
+++ b/manifests/synscan-mc019-firmware.toml
@@ -7,6 +7,7 @@ publisher = "Sky-Watcher"
 homepage = "https://www.skywatcher.com"
 category = "driver"
 type = "firmware"
+tags = ["firmware", "mount", "skywatcher"]
 slug = "synscan-mc019-firmware"
 
 [install]

--- a/manifests/synscan-mc019-firmware.toml
+++ b/manifests/synscan-mc019-firmware.toml
@@ -6,7 +6,7 @@ description = "EQ3/EQ5/EQM35 firmware"
 publisher = "Sky-Watcher"
 homepage = "https://www.skywatcher.com"
 category = "driver"
-type = "resource"
+type = "firmware"
 slug = "synscan-mc019-firmware"
 
 [install]

--- a/manifests/synscan-mc020-firmware.toml
+++ b/manifests/synscan-mc020-firmware.toml
@@ -7,6 +7,7 @@ publisher = "Sky-Watcher"
 homepage = "https://www.skywatcher.com"
 category = "driver"
 type = "firmware"
+tags = ["firmware", "mount", "skywatcher"]
 slug = "synscan-mc020-firmware"
 
 [install]

--- a/manifests/synscan-mc020-firmware.toml
+++ b/manifests/synscan-mc020-firmware.toml
@@ -6,7 +6,7 @@ description = "HEQ5 firmware"
 publisher = "Sky-Watcher"
 homepage = "https://www.skywatcher.com"
 category = "driver"
-type = "resource"
+type = "firmware"
 slug = "synscan-mc020-firmware"
 
 [install]

--- a/manifests/synscan-mc021-firmware.toml
+++ b/manifests/synscan-mc021-firmware.toml
@@ -7,6 +7,7 @@ publisher = "Sky-Watcher"
 homepage = "https://www.skywatcher.com"
 category = "driver"
 type = "firmware"
+tags = ["firmware", "mount", "skywatcher"]
 slug = "synscan-mc021-firmware"
 
 [install]

--- a/manifests/synscan-mc021-firmware.toml
+++ b/manifests/synscan-mc021-firmware.toml
@@ -6,7 +6,7 @@ description = "Star Adventurer GTi firmware"
 publisher = "Sky-Watcher"
 homepage = "https://www.skywatcher.com"
 category = "driver"
-type = "resource"
+type = "firmware"
 slug = "synscan-mc021-firmware"
 
 [install]

--- a/manifests/synscan-mc029-firmware.toml
+++ b/manifests/synscan-mc029-firmware.toml
@@ -6,6 +6,7 @@ publisher = "Sky-Watcher"
 homepage = "https://www.skywatcher.com"
 category = "driver"
 type = "firmware"
+tags = ["firmware", "mount", "skywatcher"]
 slug = "synscan-mc029-firmware"
 
 [install]

--- a/manifests/synscan-mc029-firmware.toml
+++ b/manifests/synscan-mc029-firmware.toml
@@ -5,7 +5,7 @@ description = "Firmware for AZ-GTi/AZ-GTe/AZ-GTiX/Virtuoso GTi/Star Discovery/St
 publisher = "Sky-Watcher"
 homepage = "https://www.skywatcher.com"
 category = "driver"
-type = "resource"
+type = "firmware"
 slug = "synscan-mc029-firmware"
 
 [install]

--- a/manifests/synscan-mc030-firmware.toml
+++ b/manifests/synscan-mc030-firmware.toml
@@ -6,7 +6,7 @@ description = "Wave 150i/100i firmware"
 publisher = "Sky-Watcher"
 homepage = "https://www.skywatcher.com"
 category = "driver"
-type = "resource"
+type = "firmware"
 slug = "synscan-mc030-firmware"
 
 [install]

--- a/manifests/synscan-mc030-firmware.toml
+++ b/manifests/synscan-mc030-firmware.toml
@@ -7,6 +7,7 @@ publisher = "Sky-Watcher"
 homepage = "https://www.skywatcher.com"
 category = "driver"
 type = "firmware"
+tags = ["firmware", "mount", "skywatcher"]
 slug = "synscan-mc030-firmware"
 
 [install]

--- a/manifests/synscan-pro-app.toml
+++ b/manifests/synscan-pro-app.toml
@@ -6,6 +6,7 @@ publisher = "Sky-Watcher"
 homepage = "https://www.skywatcher.com"
 category = "driver"
 type = "application"
+tags = ["mount", "skywatcher"]
 slug = "synscan-pro-app"
 
 [detection]

--- a/manifests/synscan-wifi-firmware.toml
+++ b/manifests/synscan-wifi-firmware.toml
@@ -6,6 +6,7 @@ publisher = "Sky-Watcher"
 homepage = "https://www.skywatcher.com"
 category = "driver"
 type = "firmware"
+tags = ["firmware", "wifi", "skywatcher"]
 slug = "synscan-wifi-firmware"
 
 [install]

--- a/manifests/synscan-wifi-firmware.toml
+++ b/manifests/synscan-wifi-firmware.toml
@@ -5,7 +5,7 @@ description = "Firmware for SynScan WiFi adapter"
 publisher = "Sky-Watcher"
 homepage = "https://www.skywatcher.com"
 category = "driver"
-type = "resource"
+type = "firmware"
 slug = "synscan-wifi-firmware"
 
 [install]

--- a/manifests/vcredist-runtime.toml
+++ b/manifests/vcredist-runtime.toml
@@ -6,6 +6,7 @@ publisher = "Microsoft"
 homepage = "https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist"
 category = "prerequisites"
 type = "runtime"
+tags = ["runtime", "microsoft"]
 slug = "vcredist-runtime"
 
 [install]

--- a/manifests/wanderer-empire.toml
+++ b/manifests/wanderer-empire.toml
@@ -6,6 +6,7 @@ publisher = "Wanderer Astro"
 homepage = "https://www.wandererastro.com"
 category = "driver"
 type = "application"
+tags = ["power", "dew-heater", "wanderer"]
 slug = "wanderer-empire"
 
 [install]

--- a/manifests/zwo-ascom-driver-pack.toml
+++ b/manifests/zwo-ascom-driver-pack.toml
@@ -6,6 +6,7 @@ publisher = "ZWO"
 homepage = "https://www.zwoastro.com"
 category = "driver"
 type = "driver"
+tags = ["ascom", "camera", "filterwheel", "zwo"]
 slug = "zwo-ascom-driver-pack"
 
 [install]

--- a/manifests/zwo-asi-driver.toml
+++ b/manifests/zwo-asi-driver.toml
@@ -7,7 +7,7 @@ homepage = "https://www.zwoastro.com"
 category = "driver"
 type = "driver"
 slug = "zwo-asi-driver"
-tags = ["driver", "camera", "zwo", "asi"]
+tags = ["camera", "zwo"]
 
 [install]
 method = "nsis"

--- a/manifests/zwo-asistudio.toml
+++ b/manifests/zwo-asistudio.toml
@@ -4,7 +4,7 @@ name = "ZWO ASIStudio"
 description = "ZWO all-in-one imaging suite for ASI cameras"
 publisher = "ZWO"
 homepage = "https://www.zwoastro.com"
-category = "capture"
+category = "imaging"
 type = "application"
 slug = "zwo-asistudio"
 

--- a/manifests/zwo-asistudio.toml
+++ b/manifests/zwo-asistudio.toml
@@ -6,6 +6,7 @@ publisher = "ZWO"
 homepage = "https://www.zwoastro.com"
 category = "imaging"
 type = "application"
+tags = ["imaging", "capture", "zwo"]
 slug = "zwo-asistudio"
 
 [detection]

--- a/manifests/zwo-firmware-tool.toml
+++ b/manifests/zwo-firmware-tool.toml
@@ -6,6 +6,7 @@ publisher = "ZWO"
 homepage = "https://www.zwoastro.com"
 category = "utility"
 type = "application"
+tags = ["firmware", "zwo"]
 slug = "zwo-firmware-tool"
 
 [detection]

--- a/manifests/zwo-firmware-tool.toml
+++ b/manifests/zwo-firmware-tool.toml
@@ -4,7 +4,7 @@ name = "ZWO Firmware Upgrade Tool"
 description = "Firmware update utility for ZWO devices"
 publisher = "ZWO"
 homepage = "https://www.zwoastro.com"
-category = "utilities"
+category = "utility"
 type = "application"
 slug = "zwo-firmware-tool"
 

--- a/manifests/zwo-native-driver.toml
+++ b/manifests/zwo-native-driver.toml
@@ -5,7 +5,7 @@ description = "Native USB camera driver for all ZWO ASI cameras"
 publisher = "ZWO"
 homepage = "https://www.zwoastro.com"
 category = "driver"
-type = "usb_driver"
+type = "driver"
 slug = "zwo-native-driver"
 
 [detection]

--- a/manifests/zwo-native-driver.toml
+++ b/manifests/zwo-native-driver.toml
@@ -6,6 +6,7 @@ publisher = "ZWO"
 homepage = "https://www.zwoastro.com"
 category = "driver"
 type = "driver"
+tags = ["camera", "zwo"]
 slug = "zwo-native-driver"
 
 [detection]


### PR DESCRIPTION
## Summary

- Normalize `category` values: `capture` to `imaging` (9 manifests), `utilities` to `utility` (6), `usb` to `driver` (2)
- Normalize `type` values: `usb_driver` to `driver` (5 manifests), `resource` to `firmware` (22 firmware manifests)
- Fix NINA tags: remove `phd2` and `platesolving` (separate products), add `automation`
- Fix dotnet-desktop-8 checkver regex to match "\.NET Desktop Runtime" instead of overly broad "\.NET 8"
- Add `hae`, `HAE`, `Astronomia` to `_typos.toml` (iOptron HAE product name, Lunatico Astronomia company name)

### Files changed (44)

| Change | Count | Files |
|--------|-------|-------|
| `category`: `capture` -> `imaging` | 9 | nina-app, nina-framing-cache-{full,northern,northern-starless}, apt-app, firecapture-app, sharpcap-app, zwo-asistudio, primaluce-play |
| `category`: `utilities` -> `utility` | 6 | ascom-remote-app, green-swamp-server-app, eqmod-app, qhy-polemaster, zwo-firmware-tool, primaluce-eagle-x |
| `category`: `usb` -> `driver` | 2 | cp210x-drivers, prolific-drivers |
| `type`: `usb_driver` -> `driver` | 5 | cp210x-drivers, prolific-drivers, sx-native-driver, zwo-native-driver, player-one-native-driver |
| `type`: `resource` -> `firmware` | 22 | All `*-firmware` manifests |
| `tags` fix (nina-app) | 1 | nina-app |
| `checkver.regex` fix | 1 | dotnet-desktop-8 |
| typos config | 1 | _typos.toml |
