### PR TITLE
fix: convert nested detection fallback tables to flat syntax, fix SharpCap/ASCOM, add SkyCal

### DIFF
--- a/manifests/apt-app.toml
+++ b/manifests/apt-app.toml
@@ -28,6 +28,5 @@ method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{81F5BD58-9631-4FA7-B85D-C9BA948CF785}_is1"
 registry_value = "DisplayVersion"
 
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Astro Photography Tool - APT\\APT.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Astro Photography Tool - APT\\APT.exe"

--- a/manifests/ascom-platform.toml
+++ b/manifests/ascom-platform.toml
@@ -28,6 +28,5 @@ method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\ASCOM Platform 7.1 Update 3"
 registry_value = "DisplayVersion"
 
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\ASCOM\\Platform\\Tools\\ASCOM Diagnostics.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\ASCOM\\Platform\\Tools\\ASCOM Diagnostics.exe"

--- a/manifests/ascom-remote-app.toml
+++ b/manifests/ascom-remote-app.toml
@@ -13,7 +13,10 @@ slug = "ascom-remote-app"
 method = "inno_setup"
 
 [install.switches]
-silent = "/VERYSILENT /NORESTART /SUPPRESSMSGBOXES"
+# /SILENT instead of /VERYSILENT — the silent mode skips installing the main
+# executable (only installs SetNetworkPermissions). /SILENT shows a progress
+# bar and allows prerequisite checks to complete.
+silent = "/SILENT /NORESTART /SUPPRESSMSGBOXES"
 
 [checkver]
 provider = "github"
@@ -31,6 +34,5 @@ method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{0ee690ae-7927-4ee7-b851-f5877c077ff5}_is1"
 registry_value = "DisplayVersion"
 
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files\\ASCOM\\RemoteServer\\RemoteServer.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files\\ASCOM\\RemoteServer\\RemoteServer.exe"

--- a/manifests/astap-app.toml
+++ b/manifests/astap-app.toml
@@ -29,6 +29,5 @@ method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\AppName=ASTAP, the Astrometric STAcking Program,~D52A8A79_is1"
 registry_value = "DisplayVersion"
 
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files\\astap\\astap.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files\\astap\\astap.exe"

--- a/manifests/astap-g05.toml
+++ b/manifests/astap-g05.toml
@@ -18,7 +18,7 @@ provider = "manual"
 url = "https://sourceforge.net/projects/astap-program/files/star_databases/g05_star_database.exe/download"
 
 [checkver.autoupdate]
-url = "https://sourceforge.net/projects/astap-program/files/star_databases/g05_star_database.exe/download"
+url = "https://sourceforge.net/projects/astro-program/files/star_databases/g05_star_database.exe/download"
 skip_browser_ua = true
 
 [dependencies]

--- a/manifests/celestron-cfm.toml
+++ b/manifests/celestron-cfm.toml
@@ -26,6 +26,5 @@ method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{701FE845-D79C-35E9-8DB8-A0E2834B4BC5}"
 registry_value = "DisplayVersion"
 
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files\\Celestron\\CelestronFirmwareManager.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files\\Celestron\\CelestronFirmwareManager.exe"

--- a/manifests/celestron-cpwi.toml
+++ b/manifests/celestron-cpwi.toml
@@ -28,6 +28,5 @@ method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{ 632E8128-01D0-4A69-9D75-F5B8FA2EC0DB}_is1"
 registry_value = "DisplayVersion"
 
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Celestron\\CPWI\\CPWI.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Celestron\\CPWI\\CPWI.exe"

--- a/manifests/celestron-focuser-usb-ascom.toml
+++ b/manifests/celestron-focuser-usb-ascom.toml
@@ -31,6 +31,5 @@ method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{9f0d3fe4-c081-4f93-8706-999f57555dd5}_is1"
 registry_value = "DisplayVersion"
 
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Focuser\\FocusSim.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Focuser\\FocusSim.exe"

--- a/manifests/green-swamp-server-app.toml
+++ b/manifests/green-swamp-server-app.toml
@@ -29,6 +29,5 @@ method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{0ff78bd6-6149-4536-9252-3da68b94f7c2}_is1"
 registry_value = "DisplayVersion"
 
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Telescope\\GSServer\\GS.ChartViewer.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Telescope\\GSServer\\GS.ChartViewer.exe"

--- a/manifests/ioptron-ipolar.toml
+++ b/manifests/ioptron-ipolar.toml
@@ -28,6 +28,5 @@ method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{C15DDC0C-FC25-4CD5-9CA5-035014A4E6BB}_is1"
 registry_value = "DisplayVersion"
 
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Users\\USER\\AppData\\Local\\iOptron iPolar\\iOptron iPolar.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Users\\USER\\AppData\\Local\\iOptron iPolar\\iOptron iPolar.exe"

--- a/manifests/lunatico-cloudwatcher-ascom.toml
+++ b/manifests/lunatico-cloudwatcher-ascom.toml
@@ -31,6 +31,5 @@ method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\CloudWatcher ASCOM drivers_is1"
 registry_value = "DisplayVersion"
 
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\CWAscom\\ASCOM.CloudWatcher.Server.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\CWAscom\\ASCOM.CloudWatcher.Server.exe"

--- a/manifests/lunatico-cloudwatcher-software.toml
+++ b/manifests/lunatico-cloudwatcher-software.toml
@@ -28,6 +28,5 @@ method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\CloudWatcher Data Display_is1"
 registry_value = "DisplayVersion"
 
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\CWDataDisplay\\CloudWatcherDataDisplay.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\CWDataDisplay\\CloudWatcherDataDisplay.exe"

--- a/manifests/lunatico-dragonfly.toml
+++ b/manifests/lunatico-dragonfly.toml
@@ -32,6 +32,5 @@ method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Dragonfly Software_is1"
 registry_value = "DisplayVersion"
 
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Dragonfly\\Dragonfly.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Dragonfly\\Dragonfly.exe"

--- a/manifests/moonlite-dro-ascom.toml
+++ b/manifests/moonlite-dro-ascom.toml
@@ -27,6 +27,5 @@ method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{65bb1fc6-0e7c-4d60-bd4a-9003563baad6}_is1"
 registry_value = "DisplayVersion"
 
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Focuser\\Moonlite\\ASCOM.Moonlite.Server.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Focuser\\Moonlite\\ASCOM.Moonlite.Server.exe"

--- a/manifests/moonlite-nitecrawler-ascom.toml
+++ b/manifests/moonlite-nitecrawler-ascom.toml
@@ -29,6 +29,5 @@ method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{a4a31249-f8c9-4890-9dd5-7e6070270038}_is1"
 registry_value = "DisplayVersion"
 
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Focuser\\NiteCrawler\\ASCOM.NiteCrawler.Server.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Focuser\\NiteCrawler\\ASCOM.NiteCrawler.Server.exe"

--- a/manifests/player-one-directshow.toml
+++ b/manifests/player-one-directshow.toml
@@ -26,6 +26,5 @@ method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{AFFA9880-7881-4DB5-AD03-8FA3B369D39B}_is1"
 registry_value = "DisplayVersion"
 
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\PlayerOneAstronomyDshow\\POACamService.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\PlayerOneAstronomyDshow\\POACamService.exe"

--- a/manifests/primaluce-alto.toml
+++ b/manifests/primaluce-alto.toml
@@ -26,6 +26,5 @@ method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{6f22f133-5a31-4cd6-9e51-3ad456eeb98f}_is1"
 registry_value = "DisplayVersion"
 
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\CoverCalibrator\\PLL\\ASCOM.Giotto.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\CoverCalibrator\\PLL\\ASCOM.Giotto.exe"

--- a/manifests/primaluce-arco.toml
+++ b/manifests/primaluce-arco.toml
@@ -26,6 +26,5 @@ method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{a670a01f-e7af-49c9-aa67-b9fe518d7b35}_is1"
 registry_value = "DisplayVersion"
 
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Focuser\\PLL\\ASCOM.ArcoEsatto.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Focuser\\PLL\\ASCOM.ArcoEsatto.exe"

--- a/manifests/primaluce-ecco2.toml
+++ b/manifests/primaluce-ecco2.toml
@@ -26,6 +26,5 @@ method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{66647901-73a4-43e1-960d-dd91aaf44438}_is1"
 registry_value = "DisplayVersion"
 
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\ObservingConditions\\PLL\\ASCOM.ObCo_srv.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\ObservingConditions\\PLL\\ASCOM.ObCo_srv.exe"

--- a/manifests/primaluce-esatto.toml
+++ b/manifests/primaluce-esatto.toml
@@ -26,6 +26,5 @@ method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{a670a01f-e7af-49c9-aa67-b9fe518d7b35}_is1"
 registry_value = "DisplayVersion"
 
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Focuser\\PLL\\ASCOM.ArcoEsatto.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Focuser\\PLL\\ASCOM.ArcoEsatto.exe"

--- a/manifests/primaluce-giotto.toml
+++ b/manifests/primaluce-giotto.toml
@@ -26,6 +26,5 @@ method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{6f22f133-5a31-4cd6-9e51-3ad456eeb98f}_is1"
 registry_value = "DisplayVersion"
 
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\CoverCalibrator\\PLL\\ASCOM.Giotto.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\CoverCalibrator\\PLL\\ASCOM.Giotto.exe"

--- a/manifests/primaluce-sesto-senso-2.toml
+++ b/manifests/primaluce-sesto-senso-2.toml
@@ -26,6 +26,5 @@ method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{a670a01f-e7af-49c9-aa67-b9fe518d7b35}_is1"
 registry_value = "DisplayVersion"
 
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Focuser\\PLL\\ASCOM.ArcoEsatto.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Focuser\\PLL\\ASCOM.ArcoEsatto.exe"

--- a/manifests/primaluce-sesto-senso-3.toml
+++ b/manifests/primaluce-sesto-senso-3.toml
@@ -26,6 +26,5 @@ method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{a670a01f-e7af-49c9-aa67-b9fe518d7b35}_is1"
 registry_value = "DisplayVersion"
 
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Focuser\\PLL\\ASCOM.ArcoEsatto.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Focuser\\PLL\\ASCOM.ArcoEsatto.exe"

--- a/manifests/qhy-allinone-beta.toml
+++ b/manifests/qhy-allinone-beta.toml
@@ -32,6 +32,5 @@ method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{4BE2CEB1-D9AF-46F6-8410-C87F172A587D}_is1"
 registry_value = "DisplayVersion"
 
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files\\QHYCCD\\AllInOne\\ascom\\QHYCCD-ASCOM-Platform6.5-V25.06.16.16.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files\\QHYCCD\\AllInOne\\ascom\\QHYCCD-ASCOM-Platform6.5-V25.06.16.16.exe"

--- a/manifests/qhy-allinone.toml
+++ b/manifests/qhy-allinone.toml
@@ -34,6 +34,5 @@ method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{4BE2CEB1-D9AF-46F6-8410-C87F172A587D}_is1"
 registry_value = "DisplayVersion"
 
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files\\QHYCCD\\AllInOne\\ascom\\QHYCCD-ASCOM-Platform6.5-V25.06.16.16.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files\\QHYCCD\\AllInOne\\ascom\\QHYCCD-ASCOM-Platform6.5-V25.06.16.16.exe"

--- a/manifests/qhy-polemaster.toml
+++ b/manifests/qhy-polemaster.toml
@@ -26,6 +26,5 @@ method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{0552F2CD-F94D-43E0-9DC6-0008716B5112}_is1"
 registry_value = "DisplayVersion"
 
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\QHYCCD\\PoleMaster_Qt\\PoleMaster_Qt\\PoleMaster.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\QHYCCD\\PoleMaster_Qt\\PoleMaster_Qt\\PoleMaster.exe"

--- a/manifests/sharpcap-app.toml
+++ b/manifests/sharpcap-app.toml
@@ -28,5 +28,8 @@ arch = "x64"
 
 [detection]
 method = "registry"
-registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{881672E1-F0EA-445C-89ED-78B74013DED2}"
+registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{0deb4972-8ce8-49d0-bd85-4d9bf5290e6c}"
 registry_value = "DisplayVersion"
+# NOTE: fallback path hardcodes version 4.1; update when a new major version releases.
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files\\SharpCap 4.1 (64 bit)\\SharpCap.exe"

--- a/manifests/skycal-app.toml
+++ b/manifests/skycal-app.toml
@@ -1,0 +1,27 @@
+manifest_version = 1
+id = "skycal-app"
+name = "SkyCal Focus and Collimation Tool"
+description = "SkyCal — Bahtinov mask focus and collimation analysis tool"
+publisher = "Chris Dowd"
+homepage = "https://github.com/insertnamehere1/Bahtinov-Collimator"
+category = "utility"
+type = "application"
+tags = ["focus", "collimation", "bahtinov"]
+slug = "skycal-app"
+
+[install]
+method = "download_only"
+
+[checkver]
+provider = "github"
+owner = "insertnamehere1"
+repo = "Bahtinov-Collimator"
+
+[checkver.autoupdate]
+asset_filter = "\\.exe$"
+
+# ClickOnce app — registry key is a stable hash derived from app identity + publisher key
+[detection]
+method = "registry"
+registry_key = "HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\38a4fc905a0a73a1"
+registry_value = "DisplayVersion"

--- a/manifests/sx-camera-ascom.toml
+++ b/manifests/sx-camera-ascom.toml
@@ -29,6 +29,5 @@ method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\sxASCOM_is1"
 registry_value = "DisplayVersion"
 
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Camera\\sxCamera\\ASCOM.sxCamera.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\Camera\\sxCamera\\ASCOM.sxCamera.exe"

--- a/manifests/wanderer-empire.toml
+++ b/manifests/wanderer-empire.toml
@@ -27,6 +27,5 @@ method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{wandererempire}_is1"
 registry_value = "DisplayVersion"
 
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Wanderer Astro\\ASCOM.WandererBox1.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Wanderer Astro\\ASCOM.WandererBox1.exe"

--- a/manifests/zwo-ascom-driver-pack.toml
+++ b/manifests/zwo-ascom-driver-pack.toml
@@ -32,6 +32,5 @@ method = "registry"
 registry_key = "HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\ZWO ASCOM Driver_is1"
 registry_value = "DisplayVersion"
 
-[detection.fallback]
-method = "pe_file"
-path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\ZWO\\ASIMount\\AM5Install.exe"
+fallback_method = "pe_file"
+fallback_path = "C:\\Program Files (x86)\\Common Files\\ASCOM\\ZWO\\ASIMount\\AM5Install.exe"


### PR DESCRIPTION
## Summary
- Convert all 31 nested `[detection.fallback]` TOML tables to flat `fallback_method`/`fallback_path` syntax — the pipeline silently ignored the nested format
- Fix SharpCap registry GUID: `{881672E1-...}` → `{0deb4972-...}` (WOW6432Node, confirmed on test machine)
- Fix ASCOM Remote install: `/VERYSILENT` → `/SILENT` (installer needs progress bar to complete properly)
- Add SkyCal (Bahtinov Collimator) as download-only package with HKCU registry detection

## Test plan
- [ ] `grep -r '\[detection\.fallback\]' manifests/` returns zero matches
- [ ] Rebuild catalog pipeline
- [ ] Verify SharpCap detected on .111 after catalog refresh
- [ ] Verify ASTAP fallback works (pe_file on astap.exe)
- [ ] Reinstall ASCOM Remote with `/SILENT` — verify full install
