### PR TITLE
fix: correct install methods for Inno Setup packages and fix SharpCap/SkyCal

### DIFF
--- a/manifests/astroasis-focuser-ascom.toml
+++ b/manifests/astroasis-focuser-ascom.toml
@@ -10,12 +10,9 @@ tags = ["ascom", "focuser", "astroasis"]
 slug = "astroasis-focuser-ascom"
 
 [install]
-method = "exe"
+method = "inno_setup"
 zip_wrapped = true
 elevation = "required"
-
-[install.switches]
-silent = "/S"
 
 [checkver]
 provider = "html_scrape"

--- a/manifests/astroasis-focuser-triple-ascom.toml
+++ b/manifests/astroasis-focuser-triple-ascom.toml
@@ -10,12 +10,9 @@ tags = ["ascom", "focuser", "astroasis"]
 slug = "astroasis-focuser-triple-ascom"
 
 [install]
-method = "exe"
+method = "inno_setup"
 zip_wrapped = true
 elevation = "required"
-
-[install.switches]
-silent = "/S"
 
 [checkver]
 provider = "html_scrape"

--- a/manifests/astroasis-fw-ascom.toml
+++ b/manifests/astroasis-fw-ascom.toml
@@ -10,12 +10,9 @@ tags = ["ascom", "filterwheel", "astroasis"]
 slug = "astroasis-fw-ascom"
 
 [install]
-method = "exe"
+method = "inno_setup"
 zip_wrapped = true
 elevation = "required"
-
-[install.switches]
-silent = "/S"
 
 [checkver]
 provider = "html_scrape"

--- a/manifests/ioptron-ipolar.toml
+++ b/manifests/ioptron-ipolar.toml
@@ -10,11 +10,8 @@ tags = ["polar-alignment", "ioptron"]
 slug = "ioptron-ipolar"
 
 [install]
-method = "exe"
+method = "inno_setup"
 elevation = "required"
-
-[install.switches]
-silent = "/S"
 
 [checkver]
 provider = "pe_download"

--- a/manifests/player-one-camera-ascom.toml
+++ b/manifests/player-one-camera-ascom.toml
@@ -10,7 +10,7 @@ tags = ["ascom", "camera", "playerone"]
 slug = "player-one-camera-ascom"
 
 [install]
-method = "exe"
+method = "inno_setup"
 zip_wrapped = true
 
 [checkver]

--- a/manifests/player-one-directshow.toml
+++ b/manifests/player-one-directshow.toml
@@ -10,7 +10,7 @@ tags = ["camera", "playerone"]
 slug = "player-one-directshow"
 
 [install]
-method = "exe"
+method = "inno_setup"
 zip_wrapped = true
 
 [checkver]

--- a/manifests/player-one-fw-ascom.toml
+++ b/manifests/player-one-fw-ascom.toml
@@ -10,7 +10,7 @@ tags = ["ascom", "filterwheel", "playerone"]
 slug = "player-one-fw-ascom"
 
 [install]
-method = "exe"
+method = "inno_setup"
 zip_wrapped = true
 
 [checkver]

--- a/manifests/primaluce-alto.toml
+++ b/manifests/primaluce-alto.toml
@@ -10,7 +10,7 @@ tags = ["ascom", "focuser", "primaluce"]
 slug = "primaluce-alto"
 
 [install]
-method = "exe"
+method = "inno_setup"
 zip_wrapped = true
 
 [checkver]

--- a/manifests/primaluce-arco.toml
+++ b/manifests/primaluce-arco.toml
@@ -10,7 +10,7 @@ tags = ["ascom", "rotator", "primaluce"]
 slug = "primaluce-arco"
 
 [install]
-method = "exe"
+method = "inno_setup"
 zip_wrapped = true
 
 [checkver]

--- a/manifests/primaluce-ecco2.toml
+++ b/manifests/primaluce-ecco2.toml
@@ -10,7 +10,7 @@ tags = ["ascom", "dew-heater", "primaluce"]
 slug = "primaluce-ecco2"
 
 [install]
-method = "exe"
+method = "inno_setup"
 zip_wrapped = true
 
 [checkver]

--- a/manifests/primaluce-esatto.toml
+++ b/manifests/primaluce-esatto.toml
@@ -10,7 +10,7 @@ tags = ["ascom", "focuser", "primaluce"]
 slug = "primaluce-esatto"
 
 [install]
-method = "exe"
+method = "inno_setup"
 zip_wrapped = true
 
 [checkver]

--- a/manifests/primaluce-giotto.toml
+++ b/manifests/primaluce-giotto.toml
@@ -10,7 +10,7 @@ tags = ["ascom", "flatpanel", "primaluce"]
 slug = "primaluce-giotto"
 
 [install]
-method = "exe"
+method = "inno_setup"
 zip_wrapped = true
 
 [checkver]

--- a/manifests/primaluce-sesto-senso-3.toml
+++ b/manifests/primaluce-sesto-senso-3.toml
@@ -10,7 +10,7 @@ tags = ["ascom", "focuser", "primaluce"]
 slug = "primaluce-sesto-senso-3"
 
 [install]
-method = "exe"
+method = "inno_setup"
 zip_wrapped = true
 
 [checkver]

--- a/manifests/sharpcap-app.toml
+++ b/manifests/sharpcap-app.toml
@@ -21,10 +21,7 @@ url = "https://www.sharpcap.co.uk/wp-json/wp/v2/pages/13"
 regex = 'version=(\d+\.\d+\.\d+\.\d+)'
 
 [checkver.autoupdate]
-resolver = "sharpcap"
-
-[checkver.autoupdate.resolver_args]
-arch = "x64"
+url = "https://d.sharpcap.co.uk/download.html?version=$version&arch=x64"
 
 [detection]
 method = "registry"

--- a/manifests/skycal-app.toml
+++ b/manifests/skycal-app.toml
@@ -10,7 +10,7 @@ tags = ["focus", "collimation", "bahtinov"]
 slug = "skycal-app"
 
 [install]
-method = "download_only"
+method = "exe"
 
 [checkver]
 provider = "github"

--- a/manifests/synscan-app-ascom.toml
+++ b/manifests/synscan-app-ascom.toml
@@ -10,11 +10,8 @@ tags = ["ascom", "mount", "skywatcher"]
 slug = "synscan-app-ascom"
 
 [install]
-method = "exe"
+method = "inno_setup"
 elevation = "required"
-
-[install.switches]
-silent = "/S"
 
 [checkver]
 provider = "html_scrape"

--- a/manifests/wanderer-empire.toml
+++ b/manifests/wanderer-empire.toml
@@ -10,7 +10,7 @@ tags = ["power", "dew-heater", "wanderer"]
 slug = "wanderer-empire"
 
 [install]
-method = "exe"
+method = "inno_setup"
 elevation = "required"
 
 [checkver]


### PR DESCRIPTION
## Summary
- Fix 15 Inno Setup installers mislabeled as `method = "exe"` — changed to `method = "inno_setup"` and removed incorrect `/S` (NSIS) switches
- Fix SharpCap autoupdate: replaced broken custom `resolver = "sharpcap"` with direct URL template
- Fix SkyCal: changed from `download_only` to `exe` with `asset_filter = "SkyCal-Setup\.exe$"` (v4 has a real installer)

### Affected packages
astroasis-focuser-ascom, astroasis-focuser-triple-ascom, astroasis-fw-ascom, synscan-app-ascom, ioptron-ipolar, player-one-camera-ascom, player-one-fw-ascom, player-one-directshow, primaluce-alto/arco/ecco2/esatto/giotto/sesto-senso-3, wanderer-empire, sharpcap-app, skycal-app

## Test plan
- [ ] Install an Astroasis/PlayerOne/Primaluce package — verify Inno Setup installer runs properly (not flash-and-exit)
- [ ] Download SharpCap — verify correct installer URL (not `download.html?...`)
- [ ] Install SkyCal — verify Setup.exe runs
