### PR TITLE
fix: use SkyCal online bootstrapper (ClickOnce Setup.exe)

### DIFF
--- a/manifests/skycal-app.toml
+++ b/manifests/skycal-app.toml
@@ -9,6 +9,7 @@ type = "application"
 tags = ["focus", "collimation", "bahtinov"]
 slug = "skycal-app"
 
+# ClickOnce bootstrapper — downloads and installs via ClickOnce
 [install]
 method = "exe"
 
@@ -18,7 +19,7 @@ owner = "insertnamehere1"
 repo = "Bahtinov-Collimator"
 
 [checkver.autoupdate]
-asset_filter = "\\.exe$"
+asset_filter = "SkyCal-Setup\\.exe$"
 
 # ClickOnce app — registry key is a stable hash derived from app identity + publisher key
 [detection]


### PR DESCRIPTION
Use `SkyCal-Setup.exe` (562KB online ClickOnce bootstrapper) instead of the offline zip. The offline zip contains two exe files and `zip_wrapped` handler picks the wrong one (the app instead of the installer).
