### PR TITLE
fix: restore sharpcap download resolver instead of static URL

### DIFF
--- a/manifests/sharpcap-app.toml
+++ b/manifests/sharpcap-app.toml
@@ -21,7 +21,10 @@ url = "https://www.sharpcap.co.uk/wp-json/wp/v2/pages/13"
 regex = 'version=(\d+\.\d+\.\d+\.\d+)'
 
 [checkver.autoupdate]
-url = "https://d.sharpcap.co.uk/download.html?version=$version&arch=x64"
+resolver = "sharpcap"
+
+[checkver.autoupdate.resolver_args]
+arch = "x64"
 
 [detection]
 method = "registry"


### PR DESCRIPTION
Restore the `resolver = "sharpcap"` autoupdate config. The static URL was an HTML page, not a direct download. The sharpcap resolver in `crates/checker/src/providers/sharpcap_url.rs` generates the obfuscated download URL correctly.
