### PR TITLE
fix: SkyCal v4 detection key + ASTAP binary version_regex

### DIFF
--- a/crates/checker/src/providers/static_version.rs
+++ b/crates/checker/src/providers/static_version.rs
@@ -2,6 +2,9 @@ use astro_up_shared::manifest::{Checkver, Manifest};
 
 use super::{CheckError, CheckOutcome, CheckResult};
 
+/// # Errors
+///
+/// Returns `CheckError::Other` if the `version` field is missing from checkver.
 pub fn check(manifest: &Manifest, checkver: &Checkver) -> Result<CheckOutcome, CheckError> {
     let version = checkver.version.as_deref().ok_or_else(|| {
         CheckError::Other(format!(

--- a/crates/checker/tests/github_provider.rs
+++ b/crates/checker/tests/github_provider.rs
@@ -35,6 +35,7 @@ fn github_manifest(owner: &str, repo: &str) -> Manifest {
         install: Install {
             method: "exe".into(),
             zip_wrapped: true,
+            zip_inner_path: None,
             scope: None,
             elevation: None,
             switches: HashMap::default(),
@@ -43,6 +44,7 @@ fn github_manifest(owner: &str, repo: &str) -> Manifest {
         },
         checkver: Some(Checkver {
             provider: "github".into(),
+            version: None,
             owner: Some(owner.into()),
             repo: Some(repo.into()),
             url: None,

--- a/crates/compiler/src/compile.rs
+++ b/crates/compiler/src/compile.rs
@@ -158,6 +158,12 @@ fn insert_detection(
             if let Some(p) = path {
                 map.insert("file_path".into(), serde_json::Value::String(p.clone()));
             }
+            if let Some(ref re) = detection.fallback_version_regex {
+                map.insert(
+                    "version_regex".into(),
+                    serde_json::Value::String(re.clone()),
+                );
+            }
             Some(serde_json::Value::Object(map).to_string())
         }
         _ => None,

--- a/crates/compiler/tests/compile.rs
+++ b/crates/compiler/tests/compile.rs
@@ -57,7 +57,7 @@ fn query_by_category() {
         .prepare("SELECT id FROM packages WHERE category = ?1")
         .expect("category query should prepare");
     let ids: Vec<String> = stmt
-        .query_map(["capture"], |row| row.get(0))
+        .query_map(["imaging"], |row| row.get(0))
         .expect("category query should execute")
         .filter_map(std::result::Result::ok)
         .collect();

--- a/crates/shared/src/manifest.rs
+++ b/crates/shared/src/manifest.rs
@@ -71,6 +71,8 @@ pub struct Detection {
     pub fallback_path: Option<String>,
     #[serde(default)]
     pub fallback_method: Option<String>,
+    #[serde(default)]
+    pub fallback_version_regex: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/manifests/astap-app.toml
+++ b/manifests/astap-app.toml
@@ -31,3 +31,6 @@ registry_value = "DisplayVersion"
 
 fallback_method = "pe_file"
 fallback_path = "C:\\Program Files\\astap\\astap.exe"
+# PE VersionInfo is 1.0.0 (placeholder). The real date-based version is
+# embedded as "ASTAP version YYYY.MM.DD" in the binary's string constants.
+fallback_version_regex = 'ASTAP version (\d{4}\.\d{2}\.\d{2})'

--- a/manifests/skycal-app.toml
+++ b/manifests/skycal-app.toml
@@ -21,8 +21,8 @@ repo = "Bahtinov-Collimator"
 [checkver.autoupdate]
 asset_filter = "SkyCal-Setup\\.exe$"
 
-# ClickOnce app — registry key is a stable hash derived from app identity + publisher key
+# v4 uses standalone Setup.exe installer (not ClickOnce)
 [detection]
 method = "registry"
-registry_key = "HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\38a4fc905a0a73a1"
+registry_key = "HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\b51949853d8f19f1"
 registry_value = "DisplayVersion"


### PR DESCRIPTION
## Summary
- Update SkyCal detection to v4 registry key (v4 uses standalone installer, different HKCU key)
- Add `fallback_version_regex` for ASTAP binary version detection
- Wire `fallback_version_regex` through the compiler's fallback_config JSON builder

## What changed
- `manifests/skycal-app.toml`: registry key `38a4fc905a0a73a1` (v3) → `b51949853d8f19f1` (v4)
- `manifests/astap-app.toml`: add `fallback_version_regex = 'ASTAP version (\d{4}\.\d{2}\.\d{2})'`
- `crates/shared/src/manifest.rs`: add `fallback_version_regex` field to Detection struct
- `crates/compiler/src/compile.rs`: include `version_regex` in fallback_config JSON when present

## Test plan
- [ ] Compile catalog, verify ASTAP fallback_config includes version_regex
- [ ] Deploy to .111, scan — SkyCal should detect v4 (4.0.0.4), ASTAP should detect 2026.04.10
