### PR TITLE
ci(cla): don't lock PRs after merge

### DIFF
--- a/.github/workflows/cla-assistant.yml
+++ b/.github/workflows/cla-assistant.yml
@@ -34,4 +34,4 @@ jobs:
           path-to-document: "https://github.com/${{ github.repository }}/blob/main/CLA.md"
           branch: "cla-signatures"
           allowlist: "srobroek,bot*,dependabot*,renovate*,*[bot]*,sjorsr-release-bot*,nightwatch-astro-ci*"
-
+          lock-pullrequest-aftermerge: "false"


### PR DESCRIPTION
CLA Assistant defaults `lock-pullrequest-aftermerge` to true, which locks the release-please release PR after merge and breaks its post-release comment step (`Unable to create comment because issue is locked`), aborting the publish chain. Same fix already applied in nightwatch-astro/skymath (#24).