### PR TITLE
ci: attest build provenance for released binaries and the catalog

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,10 @@ jobs:
   build:
     name: Build and publish binaries
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # gh release create/upload
+      id-token: write # OIDC identity that signs the attestation
+      attestations: write # publish the attestation to this repo
     env:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"
@@ -28,6 +32,15 @@ jobs:
 
       - name: Build release binaries
         run: cargo build --release --workspace
+
+      # Attest BEFORE upload: the attestation is bound to the bytes we built, so it
+      # must be generated from the local artifact rather than a re-downloaded copy.
+      - name: Attest build provenance
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4.2.0
+        with:
+          subject-path: |
+            target/release/astro-up-compiler
+            target/release/astro-up-checker
 
       - name: Upload binaries to release
         env:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -20,6 +20,8 @@ jobs:
     permissions:
       contents: write
       issues: write
+      id-token: write # OIDC identity that signs the attestation
+      attestations: write # publish the attestation to this repo
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -90,6 +92,18 @@ jobs:
 
       - name: Save pipeline state
         run: tar czf pipeline-state.tar.gz checker-state.json
+
+      # Complements the minisign signature above; it does not replace it. The .minisig
+      # is what an offline consumer verifies against the committed minisign.pub, with no
+      # GitHub dependency. This attestation answers a different question — which workflow
+      # run, at which commit, built these bytes — and verifying it requires reaching
+      # GitHub. Keep both: drop the .minisig and offline verification breaks.
+      - name: Attest build provenance
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4.2.0
+        with:
+          subject-path: |
+            catalog.db
+            pipeline-state.tar.gz
 
       - name: Publish to release
         env:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,46 @@
 
 Astrophotography software manifest repository — TOML definitions, Rust compiler (TOML → SQLite), and version checker.
 
+## Verifying released artifacts
+
+Two independent checks cover the published artifacts, and they answer different
+questions. Use whichever fits your situation — or both.
+
+**Minisign signature (offline).** `catalog.db` ships with a `catalog.db.minisig`
+signature made by the pipeline's key. Verify it against the public key that `astro-up`
+itself embeds ([`minisign.pub`](https://github.com/nightwatch-astro/astro-up/blob/main/minisign.pub)
+in the astro-up repo):
+
+```bash
+gh release download catalog/latest --pattern 'catalog.db*'
+curl -sO https://raw.githubusercontent.com/nightwatch-astro/astro-up/main/minisign.pub
+minisign -Vm catalog.db -p minisign.pub
+```
+
+This needs nothing but the files and the `minisign` binary, so it works air-gapped and
+does not depend on GitHub being reachable.
+
+> **Do not use the `minisign.pub` in this repository.** It is stale — key id
+> `DAA8695754F367F7`, while the pipeline signs with `09B99E3253213132` — so verification
+> against it fails with a key-id mismatch. Tracked separately; the file in `astro-up` is
+> the authoritative copy.
+
+**Build provenance attestation (online).** Every released binary and the catalog also
+carry a GitHub artifact attestation: a signed statement recording which workflow run, at
+which commit, produced those exact bytes.
+
+```bash
+# Tool binaries
+gh attestation verify astro-up-compiler -R nightwatch-astro/astro-up-manifests
+gh attestation verify astro-up-checker  -R nightwatch-astro/astro-up-manifests
+
+# Catalog database
+gh attestation verify catalog.db -R nightwatch-astro/astro-up-manifests
+```
+
+Unlike the minisign check, this one contacts GitHub — the attestation lives with the
+repository, not in the release assets. Add `--format json` for the full predicate.
+
 ## License
 
 This project is licensed under the GNU Affero General Public License v3.0 — see [LICENSE](LICENSE) for details.


### PR DESCRIPTION
Adds [GitHub artifact attestations](https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations) to both publishing workflows, so every released artifact carries a signed statement of which workflow run, at which commit, produced those exact bytes.

## What changed

| File | Change |
|---|---|
| `.github/workflows/build.yml` | Attest `astro-up-compiler` + `astro-up-checker` before `gh release upload` |
| `.github/workflows/pipeline.yml` | Attest `catalog.db` + `pipeline-state.tar.gz`, alongside the existing minisign step |
| `README.md` | Document both verification paths (there were none) |

Both jobs gain `id-token: write` (the OIDC identity that signs) and `attestations: write` (to publish). `actions/attest` is SHA-pinned to `f7c74d2` (v4.2.0), matching the pin style Dependabot already manages here.

Attestation runs **before** upload in both workflows: the statement binds to the bytes we built, so it has to come from the local artifact rather than a re-downloaded copy.

## This complements minisign, it does not replace it

The two answer different questions, and dropping either loses something real:

- **`catalog.db.minisig`** verifies offline against a published public key, with no GitHub dependency. That is what makes air-gapped verification possible.
- **The attestation** records build provenance — which run, which commit — and verifying it requires reaching GitHub.

## Found while testing: the committed `minisign.pub` is stale

I ran the verification command before documenting it. It fails:

```console
$ gh release download catalog/latest --pattern 'catalog.db*'
$ minisign -V -m catalog.db -p minisign.pub
Signature key id in catalog.db.minisig is 09B99E3253213132
but the key id in the public key is DAA8695754F367F7
```

**The product is unaffected.** `astro-up` embeds the correct key in three identical places (`minisign.pub`, `minisign.pub.key`, `crates/astro-up-core/minisign.pub.key`), and verifying the live `catalog.db` against it succeeds — *"Signature and comment signature verified"*. Only this repo's copy is wrong: unchanged since the initial commit, and read by nothing in-tree.

So the README points at astro-up's authoritative copy and warns about the local file, rather than shipping a command that fails. **That is a mitigation, not a fix** — the stale file is still here. It should be deleted (nothing reads it, and a wrong key file is worse than none) or replaced along with a CI check that the committed key verifies the published catalog. Out of scope for this PR.

## Validation

- `actionlint` clean on both edited workflows.
- Verified `subject-path` accepts a newline-separated list against the action's own `action.yml` at the v4.2.0 tag, rather than assuming.
- Attestation itself needs GitHub OIDC and cannot be exercised locally, so **the first release after merge is the real proof** — worth watching that run.

One pre-existing `actionlint` finding (SC2086 in `pipeline.yml`) is untouched; it is present on `main` and unrelated.
