### PR TITLE
fix: manifest validation rejects the static checkver provider

### DIFF
--- a/crates/shared/src/validate.rs
+++ b/crates/shared/src/validate.rs
@@ -35,6 +35,9 @@ const KNOWN_INSTALL_METHODS: &[&str] = &[
     "download_only",
 ];
 
+// Must stay in step with the dispatch arms in `checker::providers::check`; a
+// provider the checker runs but this list omits fails validation instead, which
+// is how `static` reached a shipped manifest and broke `load_sample_manifests`.
 const KNOWN_PROVIDERS: &[&str] = &[
     "github",
     "gitlab",
@@ -45,6 +48,7 @@ const KNOWN_PROVIDERS: &[&str] = &[
     "pe_download",
     "redirect",
     "manual",
+    "static",
 ];
 
 /// Default silent install switches per installer type.


### PR DESCRIPTION
## Summary

- `KNOWN_PROVIDERS` in `crates/shared/src/validate.rs` omitted `static`, so any manifest using `provider = "static"` failed validation with `unknown checkver provider 'static'` — even though the checker dispatches it (`crates/checker/src/providers/mod.rs`).
- `manifests/eqmod-app.toml` uses that provider, so the shipped manifest set could not load: `load_sample_manifests` (`crates/compiler/tests/manifest_loading.rs`) failed on every run.

## Verification

- `cargo test -p astro-up-shared` — 36 passed
- `cargo test -p astro-up-compiler --test manifest_loading` — 7 passed (was failing)
